### PR TITLE
Emit a ChallengeCleared event

### DIFF
--- a/contracts/OptimizedForceMove.sol
+++ b/contracts/OptimizedForceMove.sol
@@ -236,16 +236,7 @@ contract OptimizedForceMove {
         );
 
         // effects
-
-        // clear the challenge:
-        ChannelStorage memory channelStorage = ChannelStorage(
-            turnNumRecord + 1,
-            0,
-            bytes32(0),
-            address(0),
-            bytes32(0)
-        );
-        channelStorageHashes[channelId] = keccak256(abi.encode(channelStorage));
+        _clearChallenge(channelId, turnNumRecord + 1);
     }
 
     function refute(
@@ -340,16 +331,7 @@ contract OptimizedForceMove {
         );
 
         // effects
-
-        // clear the challenge:
-        ChannelStorage memory channelStorage = ChannelStorage(
-            turnNumRecord,
-            0,
-            bytes32(0),
-            address(0),
-            bytes32(0)
-        );
-        channelStorageHashes[channelId] = keccak256(abi.encode(channelStorage));
+        _clearChallenge(channelId, turnNumRecord);
     }
 
     struct ChannelStorageLite {
@@ -422,14 +404,8 @@ contract OptimizedForceMove {
             'Invalid signatures'
         );
 
-        // ------------
-        // EFFECTS
-        // ------------
-
-        // clear the challenge:
-        channelStorageHashes[channelId] = keccak256(
-            abi.encode(ChannelStorage(largestTurnNum, 0, bytes32(0), address(0), bytes32(0)))
-        );
+        // effects
+        _clearChallenge(channelId, largestTurnNum);
 
     }
 
@@ -598,6 +574,13 @@ contract OptimizedForceMove {
         return true;
     }
 
+    function _clearChallenge(bytes32 channelId, uint256 newTurnNumRecord) internal {
+        channelStorageHashes[channelId] = keccak256(
+            abi.encode(ChannelStorage(newTurnNumRecord, 0, bytes32(0), address(0), bytes32(0)))
+        );
+        emit ChallengeCleared(channelId, newTurnNumRecord);
+    }
+
     // events
     event ForceMove(
         // everything needed to respond or refute
@@ -608,4 +591,6 @@ contract OptimizedForceMove {
         FixedPart fixedPart,
         ForceMoveApp.VariablePart[] variableParts
     );
+
+    event ChallengeCleared(bytes32 channelId, uint256 newTurnNumRecord);
 }

--- a/test/optimizedForceMove/forceMove.test.ts
+++ b/test/optimizedForceMove/forceMove.test.ts
@@ -5,7 +5,7 @@ import OptimizedForceMoveArtifact from '../../build/contracts/TESTOptimizedForce
 // @ts-ignore
 import countingAppArtifact from '../../build/contracts/CountingApp.json';
 import {keccak256, defaultAbiCoder, hexlify} from 'ethers/utils';
-import {HashZero, AddressZero} from 'ethers/constants';
+import {HashZero} from 'ethers/constants';
 import {
   setupContracts,
   sign,

--- a/test/optimizedForceMove/test-helpers.ts
+++ b/test/optimizedForceMove/test-helpers.ts
@@ -31,3 +31,18 @@ export const ongoinghallengeHash = keccak256(
     [5, 9999, HashZero, AddressZero, HashZero], // turnNum = 5, not yet finalized
   ),
 );
+
+export const newChallengeClearedEvent = (contract: ethers.Contract, channelId: string) => {
+  return new Promise((resolve, reject) => {
+    contract.on('ChallengeCleared', (eventChannelId, eventTurnNumRecord, event) => {
+      if (eventChannelId === channelId) {
+        // match event for this channel only
+        // event.removeListener();
+        resolve([eventChannelId, eventTurnNumRecord]);
+      }
+    });
+    setTimeout(() => {
+      reject(new Error('timeout'));
+    }, 60000);
+  });
+};


### PR DESCRIPTION
To make it easier for participants to know when a challenge has been cleared.

This PR also factors the state-changing functionality of clearing a challenge into its own function (pros: less repetition, single reference for the correct `channelStorage` format of a cleared challenge, automatically fires event). 