### PR TITLE
Optimized conclude

### DIFF
--- a/contracts/OptimizedForceMove.sol
+++ b/contracts/OptimizedForceMove.sol
@@ -415,6 +415,7 @@ contract OptimizedForceMove {
         FixedPart memory fixedPart, // don't need appDefinition
         bytes32 appPartHash,
         bytes32 outcomeHash,
+        uint8 numStates,
         uint8[] memory whoSignedWhat,
         Signature[] memory sigs
     ) public {
@@ -440,12 +441,12 @@ contract OptimizedForceMove {
             );
         }
 
-        bytes32[] memory stateHashes = new bytes32[](sigs.length);
-        for (uint256 i = 0; i < sigs.length; i++) {
+        bytes32[] memory stateHashes = new bytes32[](numStates);
+        for (uint256 i = 0; i < numStates; i++) {
             stateHashes[i] = keccak256(
                 abi.encode(
                     State(
-                        largestTurnNum - i, // turnNum
+                        largestTurnNum + i - numStates, // turnNum
                         true, // isFinal
                         channelId,
                         appPartHash,

--- a/contracts/OptimizedForceMove.sol
+++ b/contracts/OptimizedForceMove.sol
@@ -59,7 +59,6 @@ contract OptimizedForceMove {
         bytes32 channelId = keccak256(
             abi.encode(fixedPart.chainId, fixedPart.participants, fixedPart.channelNonce)
         );
-        ChannelStorage memory channelStorage;
         // ------------
         // REQUIREMENTS
         // ------------
@@ -125,15 +124,8 @@ contract OptimizedForceMove {
         // EFFECTS
         // ------------
 
-        channelStorage = ChannelStorage(
-            largestTurnNum,
-            now + fixedPart.challengeDuration,
-            stateHashes[variableParts.length - 1],
-            challenger,
-            keccak256(abi.encode(variableParts[variableParts.length - 1].outcome))
-        );
-
         emit ForceMove(
+            channelId,
             largestTurnNum,
             now + fixedPart.challengeDuration,
             challenger,
@@ -142,7 +134,17 @@ contract OptimizedForceMove {
             variableParts
         );
 
-        channelStorageHashes[channelId] = keccak256(abi.encode(channelStorage));
+        channelStorageHashes[channelId] = keccak256(
+            abi.encode(
+                ChannelStorage(
+                    largestTurnNum,
+                    now + fixedPart.challengeDuration,
+                    stateHashes[variableParts.length - 1],
+                    challenger,
+                    keccak256(abi.encode(variableParts[variableParts.length - 1].outcome))
+                )
+            )
+        );
 
     }
 
@@ -720,6 +722,7 @@ contract OptimizedForceMove {
 
     // events
     event ForceMove(
+        bytes32 indexed channelId,
         // everything needed to respond or refute
         uint256 turnNunmRecord,
         uint256 finalizesAt,
@@ -729,6 +732,6 @@ contract OptimizedForceMove {
         ForceMoveApp.VariablePart[] variableParts
     );
 
-    event ChallengeCleared(bytes32 channelId, uint256 newTurnNumRecord);
-    event Concluded(bytes32 channelId);
+    event ChallengeCleared(bytes32 indexed channelId, uint256 newTurnNumRecord);
+    event Concluded(bytes32 indexed channelId);
 }

--- a/contracts/OptimizedForceMove.sol
+++ b/contracts/OptimizedForceMove.sol
@@ -426,12 +426,9 @@ contract OptimizedForceMove {
             abi.encode(fixedPart.chainId, fixedPart.participants, fixedPart.channelNonce)
         );
 
-        if (turnNumRecord == 0) {
-            require(
-                channelStorageHashes[channelId] == bytes32(0),
-                'Channel is not open or turnNum does not match'
-            );
-        } else {
+        // EITHER there is no information stored against channelId at all (OK)
+        if (channelStorageHashes[channelId] != bytes32(0)) {
+            // OR there is, in which case we must check the channel is still open and that the committed turnNumRecord is correct
             require(
                 keccak256(
                         abi.encode(

--- a/contracts/OptimizedForceMove.sol
+++ b/contracts/OptimizedForceMove.sol
@@ -475,6 +475,7 @@ contract OptimizedForceMove {
         );
 
         require(turnNumRecord > 0, 'TurnNumRecord must be nonzero');
+        require(now < channelStorageLite.finalizesAt, 'Channel already finalized!');
 
         require(
             keccak256(

--- a/test/optimizedForceMove/concludeFromChallenge.test.ts
+++ b/test/optimizedForceMove/concludeFromChallenge.test.ts
@@ -179,8 +179,6 @@ describe('concludeFromChallenge', () => {
         [[finalizesAt, challengeStateHash, challengerAddress, outcomeHash]],
       );
 
-      const concludedEvent: any = newConcludedEvent(OptimizedForceMove, channelId);
-
       // call method in a slightly different way if expecting a revert
       if (reasonString) {
         const regex = new RegExp(
@@ -202,6 +200,7 @@ describe('concludeFromChallenge', () => {
           regex,
         );
       } else {
+        const concludedEvent: any = newConcludedEvent(OptimizedForceMove, channelId);
         const tx2 = await OptimizedForceMove.concludeFromChallenge(
           declaredTurnNumRecord,
           largestTurnNum,

--- a/test/optimizedForceMove/concludeFromChallenge.test.ts
+++ b/test/optimizedForceMove/concludeFromChallenge.test.ts
@@ -5,7 +5,7 @@ import OptimizedForceMoveArtifact from '../../build/contracts/TESTOptimizedForce
 // @ts-ignore
 import countingAppArtifact from '../../build/contracts/CountingApp.json';
 import {keccak256, defaultAbiCoder} from 'ethers/utils';
-import {setupContracts, sign, clearedChallengeHash} from './test-helpers';
+import {setupContracts, sign, newConcludedEvent, clearedChallengeHash} from './test-helpers';
 import {HashZero, AddressZero} from 'ethers/constants';
 
 const provider = new ethers.providers.JsonRpcProvider(
@@ -179,6 +179,8 @@ describe('concludeFromChallenge', () => {
         [[finalizesAt, challengeStateHash, challengerAddress, outcomeHash]],
       );
 
+      const concludedEvent: any = newConcludedEvent(OptimizedForceMove, channelId);
+
       // call method in a slightly different way if expecting a revert
       if (reasonString) {
         const regex = new RegExp(
@@ -214,6 +216,10 @@ describe('concludeFromChallenge', () => {
 
         // wait for tx to be mined
         await tx2.wait();
+
+        // catch Concluded event
+        const [eventChannelId] = await concludedEvent;
+        expect(eventChannelId).toBeDefined();
 
         // compute expected ChannelStorageHash
         blockNumber = await provider.getBlockNumber();

--- a/test/optimizedForceMove/concludeFromOpen.test.ts
+++ b/test/optimizedForceMove/concludeFromOpen.test.ts
@@ -35,12 +35,15 @@ beforeAll(async () => {
 // Scenarios are synonymous with channelNonce:
 
 const description1 =
-  'It accepts a valid concludeFromOpen tx and sets the channel storage correctly';
+  'It accepts a valid concludeFromOpen tx (n states) and sets the channel storage correctly';
+const description2 =
+  'It accepts a valid concludeFromOpen tx (1 state) and sets the channel storage correctly';
 
 describe('respondWithAlternative', () => {
   it.each`
-    description     | channelNonce | declaredTurnNumRecord | initialChannelStorageHash | largestTurnNum | whoSignedWhat | reasonString
-    ${description1} | ${401}       | ${0}                  | ${HashZero}               | ${8}           | ${[0, 1, 2]}  | ${undefined}
+    description     | channelNonce | declaredTurnNumRecord | initialChannelStorageHash | largestTurnNum | numStates | whoSignedWhat | reasonString
+    ${description1} | ${401}       | ${0}                  | ${HashZero}               | ${8}           | ${3}      | ${[0, 1, 2]}  | ${undefined}
+    ${description2} | ${402}       | ${0}                  | ${HashZero}               | ${8}           | ${1}      | ${[0, 0, 0]}  | ${undefined}
   `(
     '$description', // for the purposes of this test, chainId and participants are fixed, making channelId 1-1 with channelNonce
     async ({
@@ -48,6 +51,7 @@ describe('respondWithAlternative', () => {
       declaredTurnNumRecord,
       initialChannelStorageHash,
       largestTurnNum,
+      numStates,
       whoSignedWhat,
       reasonString,
     }) => {
@@ -75,11 +79,10 @@ describe('respondWithAlternative', () => {
       );
 
       // compute stateHashes
-      // const variableParts = new Array(wallets.length);
-      const stateHashes = new Array(wallets.length);
-      for (let i = 0; i < wallets.length; i++) {
+      const stateHashes = new Array(numStates);
+      for (let i = 0; i < numStates; i++) {
         const state = {
-          turnNum: largestTurnNum - i,
+          turnNum: largestTurnNum + i - numStates,
           isFinal: true,
           channelId,
           appPartHash,
@@ -125,6 +128,7 @@ describe('respondWithAlternative', () => {
               fixedPart,
               appPartHash,
               outcomeHash,
+              numStates,
               whoSignedWhat,
               sigs,
             ),
@@ -137,6 +141,7 @@ describe('respondWithAlternative', () => {
           fixedPart,
           appPartHash,
           outcomeHash,
+          numStates,
           whoSignedWhat,
           sigs,
         );

--- a/test/optimizedForceMove/concludeFromOpen.test.ts
+++ b/test/optimizedForceMove/concludeFromOpen.test.ts
@@ -8,7 +8,7 @@ import {keccak256, defaultAbiCoder, hexlify} from 'ethers/utils';
 import {
   setupContracts,
   sign,
-  newChallengeClearedEvent,
+  newConcludedEvent,
   clearedChallengeHash,
   ongoingChallengeHash,
   finalizedOutcomeHash,
@@ -135,6 +135,8 @@ describe('concludeFromOpen', () => {
         sigs[i] = {v: sig.v, r: sig.r, s: sig.s};
       }
 
+      const concludedEvent: any = newConcludedEvent(OptimizedForceMove, channelId);
+
       // call method in a slightly different way if expecting a revert
       if (reasonString) {
         const regex = new RegExp(
@@ -168,6 +170,10 @@ describe('concludeFromOpen', () => {
 
         // wait for tx to be mined
         await tx2.wait();
+
+        // catch Concluded event
+        const [eventChannelId] = await concludedEvent;
+        expect(eventChannelId).toBeDefined();
 
         // compute expected ChannelStorageHash
         const blockNumber = await provider.getBlockNumber();

--- a/test/optimizedForceMove/concludeFromOpen.test.ts
+++ b/test/optimizedForceMove/concludeFromOpen.test.ts
@@ -135,8 +135,6 @@ describe('concludeFromOpen', () => {
         sigs[i] = {v: sig.v, r: sig.r, s: sig.s};
       }
 
-      const concludedEvent: any = newConcludedEvent(OptimizedForceMove, channelId);
-
       // call method in a slightly different way if expecting a revert
       if (reasonString) {
         const regex = new RegExp(
@@ -157,6 +155,7 @@ describe('concludeFromOpen', () => {
           regex,
         );
       } else {
+        const concludedEvent: any = newConcludedEvent(OptimizedForceMove, channelId);
         const tx2 = await OptimizedForceMove.concludeFromOpen(
           declaredTurnNumRecord,
           largestTurnNum,

--- a/test/optimizedForceMove/concludeFromOpen.test.ts
+++ b/test/optimizedForceMove/concludeFromOpen.test.ts
@@ -1,0 +1,165 @@
+import {ethers} from 'ethers';
+import {expectRevert} from 'magmo-devtools';
+// @ts-ignore
+import OptimizedForceMoveArtifact from '../../build/contracts/TESTOptimizedForceMove.json';
+// @ts-ignore
+import countingAppArtifact from '../../build/contracts/CountingApp.json';
+import {keccak256, defaultAbiCoder, hexlify} from 'ethers/utils';
+import {setupContracts, sign, newChallengeClearedEvent} from './test-helpers';
+import {HashZero, AddressZero} from 'ethers/constants';
+
+const provider = new ethers.providers.JsonRpcProvider(
+  `http://localhost:${process.env.DEV_GANACHE_PORT}`,
+);
+let OptimizedForceMove: ethers.Contract;
+let networkId;
+const chainId = 1234;
+const participants = ['', '', ''];
+const wallets = new Array(3);
+const challengeDuration = 1000;
+const outcome = ethers.utils.id('some outcome data'); // use a fixed outcome for all state updates in all tests
+const outcomeHash = keccak256(defaultAbiCoder.encode(['bytes'], [outcome]));
+let appDefinition;
+
+// populate wallets and participants array
+for (let i = 0; i < 3; i++) {
+  wallets[i] = ethers.Wallet.createRandom();
+  participants[i] = wallets[i].address;
+}
+beforeAll(async () => {
+  OptimizedForceMove = await setupContracts(provider, OptimizedForceMoveArtifact);
+  networkId = (await provider.getNetwork()).chainId;
+  appDefinition = countingAppArtifact.networks[networkId].address; // use a fixed appDefinition in all tests
+});
+
+// Scenarios are synonymous with channelNonce:
+
+const description1 =
+  'It accepts a valid concludeFromOpen tx and sets the channel storage correctly';
+
+describe('respondWithAlternative', () => {
+  it.each`
+    description     | channelNonce | declaredTurnNumRecord | initialChannelStorageHash | largestTurnNum | whoSignedWhat | reasonString
+    ${description1} | ${401}       | ${0}                  | ${HashZero}               | ${8}           | ${[0, 1, 2]}  | ${undefined}
+  `(
+    '$description', // for the purposes of this test, chainId and participants are fixed, making channelId 1-1 with channelNonce
+    async ({
+      channelNonce,
+      declaredTurnNumRecord,
+      initialChannelStorageHash,
+      largestTurnNum,
+      whoSignedWhat,
+      reasonString,
+    }) => {
+      // compute channelId
+      const channelId = keccak256(
+        defaultAbiCoder.encode(
+          ['uint256', 'address[]', 'uint256'],
+          [chainId, participants, channelNonce],
+        ),
+      );
+      // fixedPart
+      const fixedPart = {
+        chainId,
+        participants,
+        channelNonce,
+        appDefinition,
+        challengeDuration,
+      };
+
+      const appPartHash = keccak256(
+        defaultAbiCoder.encode(
+          ['uint256', 'address'], // note lack of appData
+          [challengeDuration, appDefinition],
+        ),
+      );
+
+      // compute stateHashes
+      // const variableParts = new Array(wallets.length);
+      const stateHashes = new Array(wallets.length);
+      for (let i = 0; i < wallets.length; i++) {
+        const state = {
+          turnNum: largestTurnNum - i,
+          isFinal: true,
+          channelId,
+          appPartHash,
+          outcomeHash,
+        };
+        stateHashes[i] = keccak256(
+          defaultAbiCoder.encode(
+            [
+              'tuple(uint256 turnNum, bool isFinal, bytes32 channelId, bytes32 appPartHash, bytes32 outcomeHash)',
+            ],
+            [state],
+          ),
+        );
+      }
+
+      // call public wrapper to set state (only works on test contract)
+      const tx = await OptimizedForceMove.setChannelStorageHash(
+        channelId,
+        initialChannelStorageHash,
+      );
+      await tx.wait();
+      expect(await OptimizedForceMove.channelStorageHashes(channelId)).toEqual(
+        initialChannelStorageHash,
+      );
+
+      // sign the states
+      const sigs = new Array(participants.length);
+      for (let i = 0; i < participants.length; i++) {
+        const sig = await sign(wallets[i], stateHashes[whoSignedWhat[i]]);
+        sigs[i] = {v: sig.v, r: sig.r, s: sig.s};
+      }
+
+      // call method in a slightly different way if expecting a revert
+      if (reasonString) {
+        const regex = new RegExp(
+          '^' + 'VM Exception while processing transaction: revert ' + reasonString + '$',
+        );
+        await expectRevert(
+          () =>
+            OptimizedForceMove.concludeFromOpen(
+              declaredTurnNumRecord,
+              largestTurnNum,
+              fixedPart,
+              appPartHash,
+              outcomeHash,
+              whoSignedWhat,
+              sigs,
+            ),
+          regex,
+        );
+      } else {
+        const tx2 = await OptimizedForceMove.concludeFromOpen(
+          declaredTurnNumRecord,
+          largestTurnNum,
+          fixedPart,
+          appPartHash,
+          outcomeHash,
+          whoSignedWhat,
+          sigs,
+        );
+
+        // wait for tx to be mined
+        await tx2.wait();
+
+        // compute expected ChannelStorageHash
+        const blockNumber = await provider.getBlockNumber();
+        const blockTimestamp = (await provider.getBlock(blockNumber)).timestamp;
+        const expectedChannelStorage = [0, blockTimestamp, HashZero, AddressZero, outcomeHash];
+        const expectedChannelStorageHash = keccak256(
+          defaultAbiCoder.encode(
+            ['uint256', 'uint256', 'bytes32', 'address', 'bytes32'],
+            expectedChannelStorage,
+          ),
+        );
+
+        // check channelStorageHash against the expected value
+        expect(await OptimizedForceMove.channelStorageHashes(channelId)).toEqual(
+          expectedChannelStorageHash,
+        );
+      }
+    },
+  );
+});

--- a/test/optimizedForceMove/forceMove.test.ts
+++ b/test/optimizedForceMove/forceMove.test.ts
@@ -11,7 +11,7 @@ import {
   sign,
   nonParticipant,
   clearedChallengeHash,
-  ongoinghallengeHash,
+  ongoingChallengeHash,
 } from './test-helpers';
 
 const provider = new ethers.providers.JsonRpcProvider(
@@ -64,7 +64,7 @@ describe('forceMove', () => {
     ${description2} | ${202}       | ${HashZero}                | ${0}          | ${8}           | ${[2]}       | ${0}         | ${[0, 0, 0]}  | ${wallets[2]}     | ${undefined}
     ${description3} | ${203}       | ${clearedChallengeHash(5)} | ${5}          | ${8}           | ${[2]}       | ${0}         | ${[0, 0, 0]}  | ${wallets[2]}     | ${undefined}
     ${description4} | ${204}       | ${clearedChallengeHash(5)} | ${5}          | ${2}           | ${[2]}       | ${0}         | ${[0, 0, 0]}  | ${wallets[2]}     | ${'Stale challenge!'}
-    ${description5} | ${205}       | ${ongoinghallengeHash(5)}  | ${5}          | ${8}           | ${[2]}       | ${0}         | ${[0, 0, 0]}  | ${wallets[2]}     | ${'Channel is not open or turnNum does not match'}
+    ${description5} | ${205}       | ${ongoingChallengeHash(5)} | ${5}          | ${8}           | ${[2]}       | ${0}         | ${[0, 0, 0]}  | ${wallets[2]}     | ${'Channel is not open or turnNum does not match'}
     ${description6} | ${206}       | ${HashZero}                | ${0}          | ${8}           | ${[0, 1, 2]} | ${0}         | ${[0, 1, 2]}  | ${nonParticipant} | ${'Challenger is not a participant'}
     ${description7} | ${207}       | ${HashZero}                | ${0}          | ${8}           | ${[0, 1, 1]} | ${0}         | ${[0, 1, 2]}  | ${wallets[2]}     | ${'CountingApp: Counter must be incremented'}
     ${description8} | ${208}       | ${HashZero}                | ${0}          | ${8}           | ${[0, 1, 2]} | ${0}         | ${[0, 0, 2]}  | ${wallets[2]}     | ${'Unacceptable whoSignedWhat array'}

--- a/test/optimizedForceMove/forceMove.test.ts
+++ b/test/optimizedForceMove/forceMove.test.ts
@@ -59,15 +59,15 @@ const description8 = 'It reverts when an unacceptable whoSignedWhat array is sub
 
 describe('forceMove', () => {
   it.each`
-    description     | channelNonce | initialChannelStorageHash | turnNumRecord | largestTurnNum | appDatas     | isFinalCount | whoSignedWhat | challenger        | reasonString
-    ${description1} | ${201}       | ${HashZero}               | ${0}          | ${8}           | ${[0, 1, 2]} | ${0}         | ${[0, 1, 2]}  | ${wallets[2]}     | ${undefined}
-    ${description2} | ${202}       | ${HashZero}               | ${0}          | ${8}           | ${[2]}       | ${0}         | ${[0, 0, 0]}  | ${wallets[2]}     | ${undefined}
-    ${description3} | ${203}       | ${clearedChallengeHash}   | ${5}          | ${8}           | ${[2]}       | ${0}         | ${[0, 0, 0]}  | ${wallets[2]}     | ${undefined}
-    ${description4} | ${204}       | ${clearedChallengeHash}   | ${5}          | ${2}           | ${[2]}       | ${0}         | ${[0, 0, 0]}  | ${wallets[2]}     | ${'Stale challenge!'}
-    ${description5} | ${205}       | ${ongoinghallengeHash}    | ${5}          | ${8}           | ${[2]}       | ${0}         | ${[0, 0, 0]}  | ${wallets[2]}     | ${'Channel is not open or turnNum does not match'}
-    ${description6} | ${206}       | ${HashZero}               | ${0}          | ${8}           | ${[0, 1, 2]} | ${0}         | ${[0, 1, 2]}  | ${nonParticipant} | ${'Challenger is not a participant'}
-    ${description7} | ${207}       | ${HashZero}               | ${0}          | ${8}           | ${[0, 1, 1]} | ${0}         | ${[0, 1, 2]}  | ${wallets[2]}     | ${'CountingApp: Counter must be incremented'}
-    ${description8} | ${208}       | ${HashZero}               | ${0}          | ${8}           | ${[0, 1, 2]} | ${0}         | ${[0, 0, 2]}  | ${wallets[2]}     | ${'Unacceptable whoSignedWhat array'}
+    description     | channelNonce | initialChannelStorageHash  | turnNumRecord | largestTurnNum | appDatas     | isFinalCount | whoSignedWhat | challenger        | reasonString
+    ${description1} | ${201}       | ${HashZero}                | ${0}          | ${8}           | ${[0, 1, 2]} | ${0}         | ${[0, 1, 2]}  | ${wallets[2]}     | ${undefined}
+    ${description2} | ${202}       | ${HashZero}                | ${0}          | ${8}           | ${[2]}       | ${0}         | ${[0, 0, 0]}  | ${wallets[2]}     | ${undefined}
+    ${description3} | ${203}       | ${clearedChallengeHash(5)} | ${5}          | ${8}           | ${[2]}       | ${0}         | ${[0, 0, 0]}  | ${wallets[2]}     | ${undefined}
+    ${description4} | ${204}       | ${clearedChallengeHash(5)} | ${5}          | ${2}           | ${[2]}       | ${0}         | ${[0, 0, 0]}  | ${wallets[2]}     | ${'Stale challenge!'}
+    ${description5} | ${205}       | ${ongoinghallengeHash(5)}  | ${5}          | ${8}           | ${[2]}       | ${0}         | ${[0, 0, 0]}  | ${wallets[2]}     | ${'Channel is not open or turnNum does not match'}
+    ${description6} | ${206}       | ${HashZero}                | ${0}          | ${8}           | ${[0, 1, 2]} | ${0}         | ${[0, 1, 2]}  | ${nonParticipant} | ${'Challenger is not a participant'}
+    ${description7} | ${207}       | ${HashZero}                | ${0}          | ${8}           | ${[0, 1, 1]} | ${0}         | ${[0, 1, 2]}  | ${wallets[2]}     | ${'CountingApp: Counter must be incremented'}
+    ${description8} | ${208}       | ${HashZero}                | ${0}          | ${8}           | ${[0, 1, 2]} | ${0}         | ${[0, 0, 2]}  | ${wallets[2]}     | ${'Unacceptable whoSignedWhat array'}
   `(
     '$description', // for the purposes of this test, chainId and participants are fixed, making channelId 1-1 with channelNonce
     async ({

--- a/test/optimizedForceMove/respond.test.ts
+++ b/test/optimizedForceMove/respond.test.ts
@@ -161,8 +161,6 @@ describe('respond', () => {
       const signature = await sign(responder, responseStateHash);
       const sig = {v: signature.v, r: signature.r, s: signature.s};
 
-      const challengeClearedEvent: any = newChallengeClearedEvent(OptimizedForceMove, channelId);
-
       if (reasonString) {
         const regex = new RegExp(
           '^' + 'VM Exception while processing transaction: revert ' + reasonString + '$',
@@ -181,6 +179,7 @@ describe('respond', () => {
           regex,
         );
       } else {
+        const challengeClearedEvent: any = newChallengeClearedEvent(OptimizedForceMove, channelId);
         // call respond
         const tx2 = await OptimizedForceMove.respond(
           declaredTurnNumRecord,

--- a/test/optimizedForceMove/respondWithAlternative.test.ts
+++ b/test/optimizedForceMove/respondWithAlternative.test.ts
@@ -170,8 +170,6 @@ describe('respondWithAlternative', () => {
         sigs[i] = {v: sig.v, r: sig.r, s: sig.s};
       }
 
-      const challengeClearedEvent: any = newChallengeClearedEvent(OptimizedForceMove, channelId);
-
       // call method in a slightly different way if expecting a revert
       if (reasonString) {
         const regex = new RegExp(
@@ -191,6 +189,7 @@ describe('respondWithAlternative', () => {
           regex,
         );
       } else {
+        const challengeClearedEvent: any = newChallengeClearedEvent(OptimizedForceMove, channelId);
         const tx2 = await OptimizedForceMove.respondWithAlternative(
           fixedPart,
           largestTurnNum,

--- a/test/optimizedForceMove/respondWithAlternative.test.ts
+++ b/test/optimizedForceMove/respondWithAlternative.test.ts
@@ -172,7 +172,7 @@ describe('respondWithAlternative', () => {
 
       const challengeClearedEvent: any = newChallengeClearedEvent(OptimizedForceMove, channelId);
 
-      // call forceMove in a slightly different way if expecting a revert
+      // call method in a slightly different way if expecting a revert
       if (reasonString) {
         const regex = new RegExp(
           '^' + 'VM Exception while processing transaction: revert ' + reasonString + '$',

--- a/test/optimizedForceMove/test-helpers.ts
+++ b/test/optimizedForceMove/test-helpers.ts
@@ -1,6 +1,5 @@
 import {ethers} from 'ethers';
-import {splitSignature, arrayify} from 'ethers/utils';
-import {keccak256, defaultAbiCoder} from 'ethers/utils';
+import {splitSignature, arrayify, keccak256, defaultAbiCoder} from 'ethers/utils';
 import {HashZero, AddressZero} from 'ethers/constants';
 
 export async function setupContracts(provider: ethers.providers.JsonRpcProvider, artifact) {
@@ -28,11 +27,21 @@ export const clearedChallengeHash = (turnNumRecord: number = 5) => {
   );
 };
 
-export const ongoinghallengeHash = (turnNumRecord: number = 5) => {
+export const ongoingChallengeHash = (turnNumRecord: number = 5) => {
   return keccak256(
     defaultAbiCoder.encode(
       ['uint256', 'uint256', 'bytes32', 'address', 'bytes32'],
       [turnNumRecord, 1e9, HashZero, AddressZero, HashZero], // turnNum = 5, not yet finalized
+    ),
+  );
+};
+
+export const finalizedOutcomeHash = (turnNumRecord: number = 5) => {
+  return keccak256(
+    defaultAbiCoder.encode(
+      ['uint256', 'uint256', 'bytes32', 'address', 'bytes32'],
+      [turnNumRecord, 1, HashZero, AddressZero, HashZero], // finalizes at 1, earliest possible
+      // the final two fields should also not be zero
     ),
   );
 };

--- a/test/optimizedForceMove/test-helpers.ts
+++ b/test/optimizedForceMove/test-helpers.ts
@@ -18,19 +18,24 @@ export async function sign(wallet: ethers.Wallet, msgHash: string | Uint8Array) 
 }
 
 export const nonParticipant = ethers.Wallet.createRandom();
-export const clearedChallengeHash = keccak256(
-  defaultAbiCoder.encode(
-    ['uint256', 'uint256', 'bytes32', 'address', 'bytes32'],
-    [5, 0, HashZero, AddressZero, HashZero], // turnNum = 5
-  ),
-);
 
-export const ongoinghallengeHash = keccak256(
-  defaultAbiCoder.encode(
-    ['uint256', 'uint256', 'bytes32', 'address', 'bytes32'],
-    [5, 9999, HashZero, AddressZero, HashZero], // turnNum = 5, not yet finalized
-  ),
-);
+export const clearedChallengeHash = (turnNumRecord: number = 5) => {
+  return keccak256(
+    defaultAbiCoder.encode(
+      ['uint256', 'uint256', 'bytes32', 'address', 'bytes32'],
+      [turnNumRecord, 0, HashZero, AddressZero, HashZero], // turnNum = 5
+    ),
+  );
+};
+
+export const ongoinghallengeHash = (turnNumRecord: number = 5) => {
+  return keccak256(
+    defaultAbiCoder.encode(
+      ['uint256', 'uint256', 'bytes32', 'address', 'bytes32'],
+      [turnNumRecord, 1e9, HashZero, AddressZero, HashZero], // turnNum = 5, not yet finalized
+    ),
+  );
+};
 
 export const newChallengeClearedEvent = (contract: ethers.Contract, channelId: string) => {
   return new Promise((resolve, reject) => {

--- a/test/optimizedForceMove/test-helpers.ts
+++ b/test/optimizedForceMove/test-helpers.ts
@@ -60,3 +60,18 @@ export const newChallengeClearedEvent = (contract: ethers.Contract, channelId: s
     }, 60000);
   });
 };
+
+export const newConcludedEvent = (contract: ethers.Contract, channelId: string) => {
+  return new Promise((resolve, reject) => {
+    contract.on('Concluded', (eventChannelId, event) => {
+      if (eventChannelId === channelId) {
+        // match event for this channel only
+        // event.removeListener();
+        resolve([channelId]);
+      }
+    });
+    setTimeout(() => {
+      reject(new Error('timeout'));
+    }, 60000);
+  });
+};


### PR DESCRIPTION
Test coverage:

`concludeFromOpen`: 
- [x] 'It accepts a valid concludeFromOpen tx (n states) and sets the channel storage correctly';
- [x] 'It accepts a valid concludeFromOpen tx (1 state) and sets the channel storage correctly';
- [x] 'It accepts a valid concludeFromOpen tx (1 state, cleared challenge exists) and sets the channel storage correctly';
- [x] 'It reverts a concludeFromOpen tx when the declaredTurnNumRecord = 0 and incorrect';
- [x] 'It reverts a concludeFromOpen tx when the declaredTurnNumRecord > 0 and incorrect';
- [x] 'It reverts a concludeFromOpen tx when there is an ongoing challenge';
- [x] 'It reverts a concludeFromOpen tx when the outcome is already finalized';

Consumes no more than 97K gas.


`concludeFromChallenge`:

- [x] 'It accepts a valid concludeFromChallenge tx (n states) and sets the channel storage correctly';
- [x] 'It reverts a concludeFromChallenge tx when there is no challenge ongoing (turnNumRecord = 0)';
- [x] 'It reverts a concludeFromChallenge tx when there is no challenge ongoing (challenge cleared)';
- [x] 'It reverts a concludeFromChallenge tx when the outcome is already finalized';


Consumes no more than 93K gas

