### PR TITLE
Fix deposit & withdraw tests

### DIFF
--- a/contracts/AssetHolder.sol
+++ b/contracts/AssetHolder.sol
@@ -67,6 +67,10 @@ contract AssetHolder {
     // ****************
     // Events
     // ****************
-    event Deposited(bytes32 destination, uint256 amountDeposited, uint256 destinationHoldings);
+    event Deposited(
+        bytes32 indexed destination,
+        uint256 amountDeposited,
+        uint256 destinationHoldings
+    );
 
 }

--- a/contracts/AssetHolder.sol
+++ b/contracts/AssetHolder.sol
@@ -13,7 +13,7 @@ contract AssetHolder {
         // Moreover, the participant should sign the address that they wish
         // to send the transaction from, preventing any replay attack.
         address participant; // the account used to sign commitment transitions
-        bytes32 destination; // either an account or a channel
+        address destination; // either an account or a channel
         uint256 amount;
         address sender; // the account used to sign transactions
     }

--- a/contracts/ERC20AssetHolder.sol
+++ b/contracts/ERC20AssetHolder.sol
@@ -65,7 +65,7 @@ contract ERC20AssetHolder is AssetHolder {
         require(holdings[_addressToBytes32(participant)] >= amount, 'Withdraw: overdrawn');
         Authorization memory authorization = Authorization(
             participant,
-            _addressToBytes32(destination),
+            destination,
             amount,
             msg.sender
         );

--- a/contracts/ERC20AssetHolder.sol
+++ b/contracts/ERC20AssetHolder.sol
@@ -7,8 +7,6 @@ contract IERC20 {
     // Abstraction of the parts of the ERC20 Interface that we need
     function transfer(address to, uint256 tokens) public returns (bool success);
     function transferFrom(address from, address to, uint256 tokens) public returns (bool success);
-    function balanceOf(address account) public view returns (uint256);
-    function allowance(address owner, address spender) public view returns (uint256);
 }
 
 contract ERC20AssetHolder is AssetHolder {

--- a/contracts/ERC20AssetHolder.sol
+++ b/contracts/ERC20AssetHolder.sol
@@ -44,8 +44,6 @@ contract ERC20AssetHolder is AssetHolder {
 
         amountDeposited = expectedHeld.add(amount).sub(holdings[destination]); // strictly positive
         // require successful deposit before updating holdings (protect against reentrancy)
-        // require(Token.balanceOf(msg.sender) > 0, 'msg.sender has no balance');
-        // require(_token.allowance(msg.sender, address(this)) > 0, 'this has no allowance');
         require(
             Token.transferFrom(msg.sender, address(this), amountDeposited),
             'Could not deposit ERC20s'

--- a/contracts/ETHAssetHolder.sol
+++ b/contracts/ETHAssetHolder.sol
@@ -50,7 +50,7 @@ contract ETHAssetHolder is AssetHolder {
         bytes32 _r,
         bytes32 _s
     ) public payable {
-        require(holdings[_addressToBytes32(participant)] >= amount, 'Withdraw: overdrawn');
+        require(holdings[_addressToBytes32(participant)] >= amount, 'Withdraw | overdrawn');
         Authorization memory authorization = Authorization(
             participant,
             destination,
@@ -60,7 +60,7 @@ contract ETHAssetHolder is AssetHolder {
 
         require(
             recoverSigner(abi.encode(authorization), _v, _r, _s) == participant,
-            'Withdraw: not authorized by participant'
+            'Withdraw | not authorized by participant'
         );
 
         holdings[_addressToBytes32(participant)] = holdings[_addressToBytes32(participant)].sub(

--- a/contracts/ETHAssetHolder.sol
+++ b/contracts/ETHAssetHolder.sol
@@ -53,7 +53,7 @@ contract ETHAssetHolder is AssetHolder {
         require(holdings[_addressToBytes32(participant)] >= amount, 'Withdraw: overdrawn');
         Authorization memory authorization = Authorization(
             participant,
-            _addressToBytes32(destination),
+            destination,
             amount,
             msg.sender
         );

--- a/test/ERC20AssetHolder/deposit.test.ts
+++ b/test/ERC20AssetHolder/deposit.test.ts
@@ -4,7 +4,7 @@ import {expectRevert} from 'magmo-devtools';
 import ERC20AssetHolderArtifact from '../../build/contracts/ERC20AssetHolder.json';
 // @ts-ignore
 import TokenArtifact from '../../build/contracts/Token.json';
-import {setupContracts, newDepositedEvent} from '../test-helpers';
+import {setupContracts, newDepositedEvent, newTransferEvent} from '../test-helpers';
 
 const provider = new ethers.providers.JsonRpcProvider(
   `http://localhost:${process.env.DEV_GANACHE_PORT}`,
@@ -14,6 +14,13 @@ let signer0Address;
 let ERC20AssetHolder: ethers.Contract;
 let Token: ethers.Contract;
 let depositedEvent;
+let transferEvent;
+const destinations = [];
+
+// populate destinations array
+for (let i = 0; i < 4; i++) {
+  destinations[i] = ethers.Wallet.createRandom().address.padEnd(66, '0');
+}
 
 beforeAll(async () => {
   ERC20AssetHolder = await setupContracts(provider, ERC20AssetHolderArtifact);
@@ -21,92 +28,83 @@ beforeAll(async () => {
   signer0Address = await signer0.getAddress();
 });
 
-const description1 = 'Deposits Tokens (msg.value = amount , expectedHeld = 0)';
-const description2 = 'Reverts deposit of Tokens (msg.value = amount, expectedHeld > holdings)';
-const description3 = 'Deposits Tokens (msg.value = amount, expectedHeld + amount < holdings)';
-const description4 =
-  'Deposits Tokens (msg.value = amount,  amount < holdings < amount + expectedHeld)';
+const description0 = 'Deposits Tokens  (expectedHeld = 0)';
+const description1 = 'Reverts deposit of Tokens (expectedHeld > holdings)';
+const description2 = 'Reverts deposit of Tokens (expectedHeld + amount < holdings)';
+const description3 = 'Deposits Tokens (amount < holdings < amount + expectedHeld)';
 
 // amounts are valueString represenationa of wei
 describe('deposit', () => {
   it.each`
-    description     | destinationType       | held   | expectedHeld | amount | msgValue | heldAfter | reasonString
-    ${description1} | ${'randomEOABytes32'} | ${'0'} | ${'0'}       | ${'1'} | ${'1'}   | ${'1'}    | ${undefined}
-    ${description2} | ${'randomEOABytes32'} | ${'0'} | ${'1'}       | ${'2'} | ${'2'}   | ${'0'}    | ${'Deposit | holdings[destination] is less than expected'}
-    ${description3} | ${'randomEOABytes32'} | ${'3'} | ${'1'}       | ${'1'} | ${'1'}   | ${'3'}    | ${undefined}
-    ${description4} | ${'randomEOABytes32'} | ${'3'} | ${'2'}       | ${'2'} | ${'2'}   | ${'4'}    | ${undefined}
-  `(
-    '$description',
-    async ({destinationType, held, expectedHeld, amount, msgValue, reasonString, heldAfter}) => {
-      held = ethers.utils.bigNumberify(held);
-      expectedHeld = ethers.utils.bigNumberify(expectedHeld);
-      amount = ethers.utils.bigNumberify(amount);
-      msgValue = ethers.utils.bigNumberify(msgValue);
-      heldAfter = ethers.utils.bigNumberify(heldAfter);
+    description     | destination        | held   | expectedHeld | amount | heldAfter | reasonString
+    ${description0} | ${destinations[0]} | ${'0'} | ${'0'}       | ${'1'} | ${'1'}    | ${undefined}
+    ${description1} | ${destinations[1]} | ${'0'} | ${'1'}       | ${'2'} | ${'0'}    | ${'Deposit | holdings[destination] is less than expected'}
+    ${description2} | ${destinations[2]} | ${'3'} | ${'1'}       | ${'1'} | ${'3'}    | ${'Deposit | holdings[destination] already meets or exceeds expectedHeld + amount'}
+    ${description3} | ${destinations[3]} | ${'3'} | ${'2'}       | ${'2'} | ${'4'}    | ${undefined}
+  `('$description', async ({destination, held, expectedHeld, amount, reasonString, heldAfter}) => {
+    held = ethers.utils.bigNumberify(held);
+    expectedHeld = ethers.utils.bigNumberify(expectedHeld);
+    amount = ethers.utils.bigNumberify(amount);
+    heldAfter = ethers.utils.bigNumberify(heldAfter);
+    const zero = ethers.utils.bigNumberify('0');
 
-      let destination;
-      if (destinationType === 'randomEOABytes32') {
-        const randomAddress = ethers.Wallet.createRandom().address;
-        destination = randomAddress.padEnd(66, '0');
-      }
+    // check msg.sender has enough tokens
+    const balance = await Token.balanceOf(signer0Address);
+    await expect(balance.gte(held.add(amount))).toBe(true);
 
-      // check msg.sender has enough tokens
-      const balance = await Token.balanceOf(signer0Address);
-      await expect(balance.gte(held.add(amount))).toBe(true);
+    // Increase allowance
+    await (await Token.increaseAllowance(ERC20AssetHolder.address, held.add(amount))).wait(); // approve enough for setup and main test
 
-      // Increase allowance by calling approve
-      await (await Token.approve(ERC20AssetHolder.address, held.add(amount))).wait(); // approve enough for setup and main test
+    // check allowance updated
+    const allowance = await Token.allowance(signer0Address, ERC20AssetHolder.address);
+    expect(
+      allowance
+        .sub(amount)
+        .sub(held)
+        .gte(0),
+    ).toBe(true);
 
-      // check allowance updated
-      const allowance = await Token.allowance(signer0Address, ERC20AssetHolder.address);
-      expect(
-        allowance
-          .sub(amount)
-          .sub(held)
-          .gte(0),
-      ).toBe(true);
+    // set holdings by depositing in the 'safest' way
 
-      // set holdings by depositing in the 'safest' way
-      if (held > 0) {
-        await (await ERC20AssetHolder.deposit(destination, 0, held)).wait();
-        expect(await ERC20AssetHolder.holdings(destination)).toEqual(held);
-      }
+    if (held > 0 && !reasonString) {
+      depositedEvent = newDepositedEvent(ERC20AssetHolder, destination);
+      transferEvent = newTransferEvent(Token, ERC20AssetHolder.address);
+      await (await ERC20AssetHolder.deposit(destination, zero, held)).wait();
+      expect(await ERC20AssetHolder.holdings(destination)).toEqual(held);
+      await depositedEvent;
+      expect(await transferEvent).toEqual(held);
+    }
 
-      // TODO catch ERC20 transfer event
+    // call method in a slightly different way if expecting a revert
+    if (reasonString) {
+      const regex = new RegExp(
+        '^' + 'VM Exception while processing transaction: revert ' + reasonString + '$',
+      );
+      await expectRevert(() => ERC20AssetHolder.deposit(destination, expectedHeld, amount), regex);
+    } else {
+      depositedEvent = newDepositedEvent(ERC20AssetHolder, destination);
+      transferEvent = newTransferEvent(Token, ERC20AssetHolder.address);
+      const balanceBefore = await Token.balanceOf(signer0Address);
+      const tx = await ERC20AssetHolder.deposit(destination, expectedHeld, amount);
+      // wait for tx to be mined
+      await tx.wait();
 
-      // call method in a slightly different way if expecting a revert
-      if (reasonString) {
-        const regex = new RegExp(
-          '^' + 'VM Exception while processing transaction: revert ' + reasonString + '$',
-        );
-        await expectRevert(
-          () =>
-            ERC20AssetHolder.deposit(destination, expectedHeld, amount, {
-              value: msgValue,
-            }),
-          regex,
-        );
-      } else {
-        depositedEvent = newDepositedEvent(ERC20AssetHolder, destination);
-        const balanceBefore = await Token.balanceOf(signer0Address);
-        const tx = await ERC20AssetHolder.deposit(destination, expectedHeld, amount);
-        // wait for tx to be mined
-        const receipt = await tx.wait();
+      // catch Deposited event
+      const [eventDestination, eventAmountDeposited, eventHoldings] = await depositedEvent;
+      expect(eventDestination.toUpperCase()).toMatch(destination.toUpperCase());
+      expect(eventAmountDeposited).toEqual(heldAfter.sub(held));
+      expect(eventHoldings).toEqual(heldAfter);
 
-        // catch Deposited event
-        const [eventDestination, eventAmountDeposited, eventHoldings] = await depositedEvent;
-        expect(eventDestination.toUpperCase()).toMatch(destination.toUpperCase());
-        expect(eventAmountDeposited).toEqual(heldAfter.sub(held));
-        expect(eventHoldings).toEqual(heldAfter);
+      // catch Transfer event
+      expect(await transferEvent).toEqual(heldAfter.sub(held));
 
-        const allocatedAmount = await ERC20AssetHolder.holdings(destination);
-        await expect(allocatedAmount).toEqual(heldAfter);
+      const allocatedAmount = await ERC20AssetHolder.holdings(destination);
+      await expect(allocatedAmount).toEqual(heldAfter);
 
-        // check for any partial refund of tokens
-        await expect(await Token.balanceOf(signer0Address)).toEqual(
-          balanceBefore.sub(eventAmountDeposited),
-        );
-      }
-    },
-  );
+      // check for any partial refund of tokens
+      await expect(await Token.balanceOf(signer0Address)).toEqual(
+        balanceBefore.sub(eventAmountDeposited),
+      );
+    }
+  });
 });

--- a/test/ERC20AssetHolder/deposit.test.ts
+++ b/test/ERC20AssetHolder/deposit.test.ts
@@ -33,7 +33,6 @@ const description1 = 'Reverts deposit of Tokens (expectedHeld > holdings)';
 const description2 = 'Reverts deposit of Tokens (expectedHeld + amount < holdings)';
 const description3 = 'Deposits Tokens (amount < holdings < amount + expectedHeld)';
 
-// amounts are valueString represenationa of wei
 describe('deposit', () => {
   it.each`
     description     | destination        | held   | expectedHeld | amount | heldAfter | reasonString
@@ -66,7 +65,7 @@ describe('deposit', () => {
 
     // set holdings by depositing in the 'safest' way
 
-    if (held > 0 && !reasonString) {
+    if (held > 0) {
       depositedEvent = newDepositedEvent(ERC20AssetHolder, destination);
       transferEvent = newTransferEvent(Token, ERC20AssetHolder.address);
       await (await ERC20AssetHolder.deposit(destination, zero, held)).wait();

--- a/test/ERC20AssetHolder/deposit.test.ts
+++ b/test/ERC20AssetHolder/deposit.test.ts
@@ -1,0 +1,112 @@
+import {ethers} from 'ethers';
+import {expectRevert} from 'magmo-devtools';
+// @ts-ignore
+import ERC20AssetHolderArtifact from '../../build/contracts/ERC20AssetHolder.json';
+// @ts-ignore
+import TokenArtifact from '../../build/contracts/Token.json';
+import {setupContracts, newDepositedEvent} from '../test-helpers';
+
+const provider = new ethers.providers.JsonRpcProvider(
+  `http://localhost:${process.env.DEV_GANACHE_PORT}`,
+);
+const signer0 = provider.getSigner(0); // convention matches setupContracts function
+let signer0Address;
+let ERC20AssetHolder: ethers.Contract;
+let Token: ethers.Contract;
+let depositedEvent;
+
+beforeAll(async () => {
+  ERC20AssetHolder = await setupContracts(provider, ERC20AssetHolderArtifact);
+  Token = await setupContracts(provider, TokenArtifact);
+  signer0Address = await signer0.getAddress();
+});
+
+const description1 = 'Deposits Tokens (msg.value = amount , expectedHeld = 0)';
+const description2 = 'Reverts deposit of Tokens (msg.value = amount, expectedHeld > holdings)';
+const description3 = 'Deposits Tokens (msg.value = amount, expectedHeld + amount < holdings)';
+const description4 =
+  'Deposits Tokens (msg.value = amount,  amount < holdings < amount + expectedHeld)';
+
+// amounts are valueString represenationa of wei
+describe('deposit', () => {
+  it.each`
+    description     | destinationType       | held   | expectedHeld | amount | msgValue | heldAfter | reasonString
+    ${description1} | ${'randomEOABytes32'} | ${'0'} | ${'0'}       | ${'1'} | ${'1'}   | ${'1'}    | ${undefined}
+    ${description2} | ${'randomEOABytes32'} | ${'0'} | ${'1'}       | ${'2'} | ${'2'}   | ${'0'}    | ${'Deposit | holdings[destination] is less than expected'}
+    ${description3} | ${'randomEOABytes32'} | ${'3'} | ${'1'}       | ${'1'} | ${'1'}   | ${'3'}    | ${undefined}
+    ${description4} | ${'randomEOABytes32'} | ${'3'} | ${'2'}       | ${'2'} | ${'2'}   | ${'4'}    | ${undefined}
+  `(
+    '$description',
+    async ({destinationType, held, expectedHeld, amount, msgValue, reasonString, heldAfter}) => {
+      held = ethers.utils.bigNumberify(held);
+      expectedHeld = ethers.utils.bigNumberify(expectedHeld);
+      amount = ethers.utils.bigNumberify(amount);
+      msgValue = ethers.utils.bigNumberify(msgValue);
+      heldAfter = ethers.utils.bigNumberify(heldAfter);
+
+      let destination;
+      if (destinationType === 'randomEOABytes32') {
+        const randomAddress = ethers.Wallet.createRandom().address;
+        destination = randomAddress.padEnd(66, '0');
+      }
+
+      // check msg.sender has enough tokens
+      const balance = await Token.balanceOf(signer0Address);
+      await expect(balance.gte(held.add(amount))).toBe(true);
+
+      // Increase allowance by calling approve
+      await (await Token.approve(ERC20AssetHolder.address, held.add(amount))).wait(); // approve enough for setup and main test
+
+      // check allowance updated
+      const allowance = await Token.allowance(signer0Address, ERC20AssetHolder.address);
+      expect(
+        allowance
+          .sub(amount)
+          .sub(held)
+          .gte(0),
+      ).toBe(true);
+
+      // set holdings by depositing in the 'safest' way
+      if (held > 0) {
+        await (await ERC20AssetHolder.deposit(destination, 0, held)).wait();
+        expect(await ERC20AssetHolder.holdings(destination)).toEqual(held);
+      }
+
+      // TODO catch ERC20 transfer event
+
+      // call method in a slightly different way if expecting a revert
+      if (reasonString) {
+        const regex = new RegExp(
+          '^' + 'VM Exception while processing transaction: revert ' + reasonString + '$',
+        );
+        await expectRevert(
+          () =>
+            ERC20AssetHolder.deposit(destination, expectedHeld, amount, {
+              value: msgValue,
+            }),
+          regex,
+        );
+      } else {
+        depositedEvent = newDepositedEvent(ERC20AssetHolder, destination);
+        const balanceBefore = await Token.balanceOf(signer0Address);
+        const tx = await ERC20AssetHolder.deposit(destination, expectedHeld, amount);
+        // wait for tx to be mined
+        const receipt = await tx.wait();
+
+        // catch Deposited event
+        const [eventDestination, eventAmountDeposited, eventHoldings] = await depositedEvent;
+        expect(eventDestination.toUpperCase()).toMatch(destination.toUpperCase());
+        expect(eventAmountDeposited).toEqual(heldAfter.sub(held));
+        expect(eventHoldings).toEqual(heldAfter);
+
+        const allocatedAmount = await ERC20AssetHolder.holdings(destination);
+        await expect(allocatedAmount).toEqual(heldAfter);
+
+        // check for any partial refund of tokens
+        await expect(await Token.balanceOf(signer0Address)).toEqual(
+          balanceBefore.sub(eventAmountDeposited),
+        );
+      }
+    },
+  );
+});

--- a/test/ERC20AssetHolder/withdraw.test.ts
+++ b/test/ERC20AssetHolder/withdraw.test.ts
@@ -1,0 +1,105 @@
+import {ethers} from 'ethers';
+import {expectRevert} from 'magmo-devtools';
+// @ts-ignore
+import ERC20AssetHolderArtifact from '../../build/contracts/ERC20AssetHolder.json';
+// @ts-ignore
+import TokenArtifact from '../../build/contracts/Token.json';
+import {setupContracts, sign} from '../test-helpers';
+import {keccak256, defaultAbiCoder} from 'ethers/utils';
+
+const provider = new ethers.providers.JsonRpcProvider(
+  `http://localhost:${process.env.DEV_GANACHE_PORT}`,
+);
+const signer0 = provider.getSigner(0); // convention matches setupContracts function
+let signer0Address;
+let ERC20AssetHolder: ethers.Contract;
+let Token: ethers.Contract;
+const AUTH_TYPES = ['address', 'address', 'uint256', 'address'];
+
+beforeAll(async () => {
+  ERC20AssetHolder = await setupContracts(provider, ERC20AssetHolderArtifact);
+  signer0Address = await signer0.getAddress();
+  Token = await setupContracts(provider, TokenArtifact);
+});
+
+const description1 = 'Withdraws Tokens (signer = participant, holdings[participant] =  amount)';
+const description2 =
+  'Reverts token withdrawal (signer =/= participant, holdings[participant] = amount';
+const description3 =
+  'Reverts token withdrawal (signer = participant, holdings[participant] < amount';
+
+// amounts are valueString represenationa of wei
+describe('deposit', () => {
+  it.each`
+    description     | held   | signer     | amount | authorized | reasonString
+    ${description1} | ${'1'} | ${signer0} | ${'1'} | ${true}    | ${undefined}
+    ${description2} | ${'1'} | ${signer0} | ${'1'} | ${false}   | ${'Withdraw | not authorized by participant'}
+    ${description3} | ${'1'} | ${signer0} | ${'2'} | ${true}    | ${'Withdraw | overdrawn'}
+  `('$description', async ({held, signer, amount, authorized, reasonString}) => {
+    held = ethers.utils.parseUnits(held, 'wei');
+    amount = ethers.utils.parseUnits(amount, 'wei');
+    const participant = ethers.Wallet.createRandom();
+
+    // check msg.sender has enough tokens
+    const balance = await Token.balanceOf(signer0Address);
+    await expect(balance.gte(held.add(amount))).toBe(true);
+
+    // Increase allowance by calling approve
+    await (await Token.approve(ERC20AssetHolder.address, held.add(amount))).wait(); // approve enough for setup and main test
+
+    // set holdings by depositing in the 'safest' way
+    if (held > 0) {
+      await (await ERC20AssetHolder.deposit(participant.address.padEnd(66, '0'), 0, held, {
+        value: held,
+      })).wait();
+      expect(await ERC20AssetHolder.holdings(participant.address.padEnd(66, '0'))).toEqual(held);
+    }
+
+    // authorize withdraw
+    const authorization = defaultAbiCoder.encode(AUTH_TYPES, [
+      participant.address,
+      signer0Address,
+      amount,
+      signer0Address,
+    ]);
+
+    const authorizer = authorized ? participant : signer;
+    const sig = await sign(authorizer, keccak256(authorization));
+
+    // call method in a slightly different way if expecting a revert
+    if (reasonString) {
+      const regex = new RegExp(
+        '^' + 'VM Exception while processing transaction: revert ' + reasonString + '$',
+      );
+      await expectRevert(
+        () =>
+          ERC20AssetHolder.withdraw(
+            participant.address,
+            signer0Address,
+            amount,
+            sig.v,
+            sig.r,
+            sig.s,
+          ),
+        regex,
+      );
+    } else {
+      const balanceBefore = await Token.balanceOf(signer0Address);
+      const tx = await ERC20AssetHolder.withdraw(
+        participant.address,
+        signer0Address,
+        amount,
+        sig.v,
+        sig.r,
+        sig.s,
+      );
+      // wait for tx to be mined
+      const receipt = await tx.wait();
+      // check for token balance change
+      await expect(await Token.balanceOf(signer0Address)).toEqual(balanceBefore.add(amount));
+      // check for holdings decrease
+      const newHoldings = await ERC20AssetHolder.holdings(participant.address.padEnd(66, '0'));
+      expect(newHoldings).toEqual(held.sub(amount));
+    }
+  });
+});

--- a/test/ETHAssetHolder/deposit.test.ts
+++ b/test/ETHAssetHolder/deposit.test.ts
@@ -7,7 +7,7 @@ import {setupContracts, newDepositedEvent} from '../test-helpers';
 const provider = new ethers.providers.JsonRpcProvider(
   `http://localhost:${process.env.DEV_GANACHE_PORT}`,
 );
-const signer = provider.getSigner(0);
+const signer = provider.getSigner(0); // convention matches setupContracts function
 let ETHAssetHolder: ethers.Contract;
 let depositedEvent;
 
@@ -30,7 +30,7 @@ describe('deposit', () => {
     ${description3} | ${'randomEOABytes32'} | ${'3'} | ${'1'}       | ${'1'} | ${'1'}   | ${'3'}    | ${'Deposit | holdings[destination] already meets or exceeds expectedHeld + amount'}
     ${description4} | ${'randomEOABytes32'} | ${'3'} | ${'2'}       | ${'2'} | ${'2'}   | ${'4'}    | ${undefined}
   `(
-    '$description', // for the purposes of this test, chainId and participants are fixed, making channelId 1-1 with channelNonce
+    '$description',
     async ({destinationType, held, expectedHeld, amount, msgValue, reasonString, heldAfter}) => {
       held = ethers.utils.parseUnits(held, 'wei');
       expectedHeld = ethers.utils.parseUnits(expectedHeld, 'wei');

--- a/test/ETHAssetHolder/deposit.test.ts
+++ b/test/ETHAssetHolder/deposit.test.ts
@@ -31,10 +31,10 @@ const description3 =
 describe('deposit', () => {
   it.each`
     description     | destination        | held   | expectedHeld | amount | msgValue | heldAfter | reasonString
+    ${description0} | ${destinations[0]} | ${'0'} | ${'0'}       | ${'1'} | ${'1'}   | ${'1'}    | ${undefined}
     ${description1} | ${destinations[1]} | ${'0'} | ${'1'}       | ${'2'} | ${'2'}   | ${'0'}    | ${'Deposit | holdings[destination] is less than expected'}
     ${description2} | ${destinations[2]} | ${'3'} | ${'1'}       | ${'1'} | ${'1'}   | ${'3'}    | ${'Deposit | holdings[destination] already meets or exceeds expectedHeld + amount'}
     ${description3} | ${destinations[3]} | ${'3'} | ${'2'}       | ${'2'} | ${'2'}   | ${'4'}    | ${undefined}
-    ${description0} | ${destinations[0]} | ${'0'} | ${'0'}       | ${'1'} | ${'1'}   | ${'1'}    | ${undefined}
   `(
     '$description',
     async ({destination, held, expectedHeld, amount, msgValue, reasonString, heldAfter}) => {
@@ -46,10 +46,12 @@ describe('deposit', () => {
 
       // set holdings by depositing in the 'safest' way
       if (held > 0) {
+        depositedEvent = newDepositedEvent(ETHAssetHolder, destination);
         await (await ETHAssetHolder.deposit(destination, 0, held, {
           value: held,
         })).wait();
         expect(await ETHAssetHolder.holdings(destination)).toEqual(held);
+        await depositedEvent;
       }
 
       // call method in a slightly different way if expecting a revert

--- a/test/ETHAssetHolder/deposit.test.ts
+++ b/test/ETHAssetHolder/deposit.test.ts
@@ -10,39 +10,39 @@ const provider = new ethers.providers.JsonRpcProvider(
 const signer = provider.getSigner(0); // convention matches setupContracts function
 let ETHAssetHolder: ethers.Contract;
 let depositedEvent;
+const destinations = [];
+
+// populate destinations array
+for (let i = 0; i < 4; i++) {
+  destinations[i] = ethers.Wallet.createRandom().address.padEnd(66, '0');
+}
 
 beforeAll(async () => {
   ETHAssetHolder = await setupContracts(provider, ETHAssetHolderArtifact);
 });
 
-const description1 = 'Deposits ETH (msg.value = amount , expectedHeld = 0)';
-const description2 = 'Reverts deposit of ETH (msg.value = amount, expectedHeld > holdings)';
-const description3 = 'Deposits ETH (msg.value = amount, expectedHeld + amount < holdings)';
-const description4 =
+const description0 = 'Deposits ETH (msg.value = amount , expectedHeld = 0)';
+const description1 = 'Reverts deposit of ETH (msg.value = amount, expectedHeld > holdings)';
+const description2 = 'Deposits ETH (msg.value = amount, expectedHeld + amount < holdings)';
+const description3 =
   'Deposits ETH (msg.value = amount,  amount < holdings < amount + expectedHeld)';
 
 // amounts are valueString represenationa of wei
 describe('deposit', () => {
   it.each`
-    description     | destinationType       | held   | expectedHeld | amount | msgValue | heldAfter | reasonString
-    ${description1} | ${'randomEOABytes32'} | ${'0'} | ${'0'}       | ${'1'} | ${'1'}   | ${'1'}    | ${undefined}
-    ${description2} | ${'randomEOABytes32'} | ${'0'} | ${'1'}       | ${'2'} | ${'2'}   | ${'0'}    | ${'Deposit | holdings[destination] is less than expected'}
-    ${description3} | ${'randomEOABytes32'} | ${'3'} | ${'1'}       | ${'1'} | ${'1'}   | ${'3'}    | ${'Deposit | holdings[destination] already meets or exceeds expectedHeld + amount'}
-    ${description4} | ${'randomEOABytes32'} | ${'3'} | ${'2'}       | ${'2'} | ${'2'}   | ${'4'}    | ${undefined}
+    description     | destination        | held   | expectedHeld | amount | msgValue | heldAfter | reasonString
+    ${description1} | ${destinations[1]} | ${'0'} | ${'1'}       | ${'2'} | ${'2'}   | ${'0'}    | ${'Deposit | holdings[destination] is less than expected'}
+    ${description2} | ${destinations[2]} | ${'3'} | ${'1'}       | ${'1'} | ${'1'}   | ${'3'}    | ${'Deposit | holdings[destination] already meets or exceeds expectedHeld + amount'}
+    ${description3} | ${destinations[3]} | ${'3'} | ${'2'}       | ${'2'} | ${'2'}   | ${'4'}    | ${undefined}
+    ${description0} | ${destinations[0]} | ${'0'} | ${'0'}       | ${'1'} | ${'1'}   | ${'1'}    | ${undefined}
   `(
     '$description',
-    async ({destinationType, held, expectedHeld, amount, msgValue, reasonString, heldAfter}) => {
+    async ({destination, held, expectedHeld, amount, msgValue, reasonString, heldAfter}) => {
       held = ethers.utils.parseUnits(held, 'wei');
       expectedHeld = ethers.utils.parseUnits(expectedHeld, 'wei');
       amount = ethers.utils.parseUnits(amount, 'wei');
       msgValue = ethers.utils.parseUnits(msgValue, 'wei');
       heldAfter = ethers.utils.parseUnits(heldAfter, 'wei');
-
-      let destination;
-      if (destinationType === 'randomEOABytes32') {
-        const randomAddress = ethers.Wallet.createRandom().address;
-        destination = randomAddress.padEnd(66, '0');
-      }
 
       // set holdings by depositing in the 'safest' way
       if (held > 0) {

--- a/test/ETHAssetHolder/withdraw.test.ts
+++ b/test/ETHAssetHolder/withdraw.test.ts
@@ -1,0 +1,80 @@
+import {ethers} from 'ethers';
+import {expectRevert} from 'magmo-devtools';
+// @ts-ignore
+import ETHAssetHolderArtifact from '../../build/contracts/ETHAssetHolder.json';
+import {setupContracts, sign} from '../test-helpers';
+import {keccak256, defaultAbiCoder} from 'ethers/utils';
+
+const provider = new ethers.providers.JsonRpcProvider(
+  `http://localhost:${process.env.DEV_GANACHE_PORT}`,
+);
+const signer0 = provider.getSigner(0); // convention matches setupContracts function
+let signer0Address;
+let ETHAssetHolder: ethers.Contract;
+const AUTH_TYPES = ['address', 'address', 'uint256', 'address'];
+
+beforeAll(async () => {
+  ETHAssetHolder = await setupContracts(provider, ETHAssetHolderArtifact);
+  signer0Address = await signer0.getAddress();
+});
+
+const description1 = 'Withdraws ETH (signer = participant, holdings[participant] = 2 * amount)';
+
+// amounts are valueString represenationa of wei
+describe('deposit', () => {
+  it.each`
+    description     | held   | signer     | amount | reasonString
+    ${description1} | ${'2'} | ${signer0} | ${'1'} | ${undefined}
+  `('$description', async ({destinationType, held, signer, amount, reasonString}) => {
+    held = ethers.utils.parseUnits(held, 'wei');
+    amount = ethers.utils.parseUnits(amount, 'wei');
+    const participant = ethers.Wallet.createRandom();
+    // set holdings by depositing in the 'safest' way
+    if (held > 0) {
+      await (await ETHAssetHolder.deposit(participant.address.padEnd(66, '0'), 0, held, {
+        value: held,
+      })).wait();
+      expect(await ETHAssetHolder.holdings(participant.address.padEnd(66, '0'))).toEqual(held);
+    }
+
+    // authorize withdraw
+    const authorization = defaultAbiCoder.encode(AUTH_TYPES, [
+      participant.address,
+      signer0Address,
+      amount,
+      signer0Address,
+    ]);
+
+    const sig = await sign(participant, keccak256(authorization));
+
+    // call method in a slightly different way if expecting a revert
+    if (reasonString) {
+      const regex = new RegExp(
+        '^' + 'VM Exception while processing transaction: revert ' + reasonString + '$',
+      );
+      await expectRevert(
+        () =>
+          ETHAssetHolder.withdraw(participant.address, signer0Address, amount, sig.v, sig.r, sig.s),
+        regex,
+      );
+    } else {
+      const balanceBefore = await signer.getBalance();
+      const tx = await ETHAssetHolder.withdraw(
+        participant.address,
+        signer0Address,
+        amount,
+        sig.v,
+        sig.r,
+        sig.s,
+      );
+      // wait for tx to be mined
+      const receipt = await tx.wait();
+      // check for EOA balance change
+      const gasCost = await tx.gasPrice.mul(receipt.cumulativeGasUsed);
+      await expect(await signer.getBalance()).toEqual(balanceBefore.add(amount).sub(gasCost));
+      // check for holdings decrease
+      const newHoldings = await ETHAssetHolder.holdings(participant.address.padEnd(66, '0'));
+      expect(newHoldings).toEqual(held.sub(amount));
+    }
+  });
+});

--- a/test/ForceMove/forceMove.test.ts
+++ b/test/ForceMove/forceMove.test.ts
@@ -4,7 +4,7 @@ import {expectRevert} from 'magmo-devtools';
 import ForceMoveArtifact from '../../build/contracts/TESTForceMove.json';
 // @ts-ignore
 import countingAppArtifact from '../../build/contracts/CountingApp.json';
-import {keccak256, defaultAbiCoder, hexlify, toUtf8Bytes} from 'ethers/utils';
+import {keccak256, defaultAbiCoder, hexlify} from 'ethers/utils';
 import {HashZero} from 'ethers/constants';
 import {
   setupContracts,

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -105,3 +105,14 @@ export const newConcludedEvent = (contract: ethers.Contract, channelId: string) 
     });
   });
 };
+
+export const newDepositedEvent = (contract: ethers.Contract, destination: string) => {
+  const filter = contract.filters.Deposited(destination);
+  return new Promise((resolve, reject) => {
+    contract.on(filter, (eventDestination, amountDeposited, amountHeld, event) => {
+      // match event for this destination only
+      contract.removeAllListeners(filter);
+      resolve([eventDestination, amountDeposited, amountHeld]);
+    });
+  });
+};

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -2,8 +2,6 @@ import {ethers} from 'ethers';
 import {splitSignature, arrayify, keccak256, defaultAbiCoder} from 'ethers/utils';
 import {HashZero, AddressZero} from 'ethers/constants';
 
-const eventEmitterTimeout = 60000; // ms
-
 export async function setupContracts(provider: ethers.providers.JsonRpcProvider, artifact) {
   const networkId = (await provider.getNetwork()).chainId;
   const signer = provider.getSigner(0);
@@ -113,6 +111,17 @@ export const newDepositedEvent = (contract: ethers.Contract, destination: string
       // match event for this destination only
       contract.removeAllListeners(filter);
       resolve([eventDestination, amountDeposited, amountHeld]);
+    });
+  });
+};
+
+export const newTransferEvent = (contract: ethers.Contract, to: string) => {
+  const filter = contract.filters.Transfer(null, to);
+  return new Promise((resolve, reject) => {
+    contract.on(filter, (eventFrom, eventTo, amountTransferred, event) => {
+      // match event for this destination only
+      contract.removeAllListeners(filter);
+      resolve(amountTransferred);
     });
   });
 };


### PR DESCRIPTION
This PR completes much more thorough testing of the `deposit` and `withdraw` functions on `ETHAssetHolder` and `ERC20AssetHolder`, including pulling data from events and testing them against expectations. 

NB: The `withdraw` function will most likely be dropped or relegated to an `internal` function in a future PR (when `transferAll` is implemented).
