### PR TITLE
Add claimAll function to AssetHolder

### DIFF
--- a/contracts/AssetHolder.sol
+++ b/contracts/AssetHolder.sol
@@ -16,7 +16,7 @@ contract AssetHolder {
     // Public methods
     // **************
 
-    function transferAll(bytes32 channelId, bytes memory allocationBytes) public {
+    function transferAll(bytes32 channelId, bytes calldata allocationBytes) external {
         // requirements
         require(
             outcomeHashes[channelId] ==
@@ -98,6 +98,128 @@ contract AssetHolder {
             } else {
                 holdings[allocation[m].destination] += payoutAmount;
             }
+        }
+
+    }
+
+    function claimAll(bytes32 channelId, bytes32 guaranteedChannelId, bytes calldata destinationsBytes, bytes calldata allocationBytes) external {
+        // requirements
+
+        require(
+            outcomeHashes[channelId] ==
+                keccak256(
+                    abi.encode(
+                        Outcome.LabelledAllocationOrGuarantee(
+                            uint8(Outcome.OutcomeType.Guarantee),
+                            destinationsBytes
+                        )
+                    )
+                ),
+            'claimAll | submitted data does not match outcomeHash stored against channelId'
+        );
+
+        require(
+            outcomeHashes[guaranteedChannelId] ==
+                keccak256(
+                    abi.encode(
+                        Outcome.LabelledAllocationOrGuarantee(
+                            uint8(Outcome.OutcomeType.Allocation),
+                            allocationBytes
+                        )
+                    )
+                ),
+            'claimAll | submitted data does not match outcomeHash stored against guaranteedChannelId'
+        );
+
+        uint256 balance = holdings[channelId];
+
+        Outcome.AllocationItem[] memory allocation = abi.decode(allocationBytes,(Outcome.AllocationItem[])); // this remains constant length
+        bytes32[] memory destinations = abi.decode(destinationsBytes,(bytes32[]));
+        uint256[] memory payouts = new uint256[](allocation.length);
+        uint256 newAllocationLength = allocation.length;
+
+        // first increase payouts according to guarantee
+        for (uint256 i = 0; i < destinations.length; i++) { // for each destination in the guarantee
+            bytes32 _destination = destinations[i];
+            if (balance == 0) {
+                break;
+            }
+            for (uint256 j = 0; j < allocation.length; j++) { 
+                if (_destination == allocation[j].destination) {  // find amount allocated to that destination (if it exists in channel alllocation)
+                    uint256 _amount = allocation[j].amount;
+                    if (balance >= _amount) {
+                        payouts[j] += _amount;
+                        allocation[j].amount = 0; // subtract _amount;
+                        newAllocationLength--; 
+                        balance -= _amount;
+                        break;
+                    } else { 
+                        payouts[j] += balance;
+                        allocation[j].amount = _amount - balance;
+                        balance = 0;
+                        break;
+                    }
+                }
+            }
+        }
+
+        // first increase payouts according to original allocation order
+        for (uint256 j = 0; j < allocation.length; j++) { // for each destination in the guarantee
+            if (balance == 0) {
+                break;
+            }   
+            uint256 _amount = allocation[j].amount;
+            if (balance >= _amount) {
+                payouts[j] += _amount;
+                allocation[j].amount = 0; // subtract _amount;
+                newAllocationLength--;
+                balance -= _amount;
+                break;
+            } else { 
+                payouts[j] += balance;
+                allocation[j].amount = _amount - balance;
+                balance = 0;
+                break;
+            }
+        }
+
+
+        // at this point have payouts array of uint256s, each corresponding to original destinations
+        // and allocations has some zero amounts which we want to prune
+        Outcome.AllocationItem[] memory newAllocation;
+        if (newAllocationLength > 0) {
+            newAllocation = new Outcome.AllocationItem[](newAllocationLength);
+        }
+
+        uint256 k = 0;
+        for (uint256 j = 0; j < allocation.length; j++) { // for each destination in the guarantee
+            if (payouts[j] > 0) {
+                if (_isExternalAddress(allocation[j].destination)) {
+                    _transferAsset(_bytes32ToAddress(allocation[j].destination), payouts[j]);
+                    emit AssetTransferred(allocation[j].destination, payouts[j]);
+                } else {
+                    holdings[allocation[j].destination] += payouts[j];
+                }
+            }
+            if (allocation[j].amount > 0 && newAllocationLength > 0) {
+                newAllocation[k] = allocation[j];
+                k++;
+            }
+        }
+        assert(k == newAllocationLength);
+
+
+        if (newAllocationLength > 0) {
+            // store hash
+            outcomeHashes[channelId] = keccak256(abi.encode(
+                Outcome.LabelledAllocationOrGuarantee(
+                            uint8(Outcome.OutcomeType.Allocation),
+                            abi.encode(newAllocation)
+                        )
+                    )
+                );
+        } else {
+            delete outcomeHashes[channelId];
         }
 
     }

--- a/contracts/AssetHolder.sol
+++ b/contracts/AssetHolder.sol
@@ -163,7 +163,7 @@ contract AssetHolder {
             }
         }
 
-        // first increase payouts according to original allocation order
+        // next, increase payouts according to original allocation order
         for (uint256 j = 0; j < allocation.length; j++) { // for each destination in the guarantee
             if (balance == 0) {
                 break;
@@ -182,7 +182,9 @@ contract AssetHolder {
                 break;
             }
         }
-
+        
+        // effects
+        holdings[channelId] = balance;
 
         // at this point have payouts array of uint256s, each corresponding to original destinations
         // and allocations has some zero amounts which we want to prune
@@ -211,7 +213,7 @@ contract AssetHolder {
 
         if (newAllocationLength > 0) {
             // store hash
-            outcomeHashes[channelId] = keccak256(abi.encode(
+            outcomeHashes[guaranteedChannelId] = keccak256(abi.encode(
                 Outcome.LabelledAllocationOrGuarantee(
                             uint8(Outcome.OutcomeType.Allocation),
                             abi.encode(newAllocation)

--- a/test/AssetHolder/claimAll.test.ts
+++ b/test/AssetHolder/claimAll.test.ts
@@ -1,0 +1,147 @@
+import {ethers} from 'ethers';
+import {expectRevert} from 'magmo-devtools';
+// @ts-ignore
+import AssetHolderArtifact from '../../build/contracts/TESTAssetHolder.json';
+import {
+  setupContracts,
+  newAssetTransferredEvent,
+  randomChannelId,
+  allocationToParams,
+  guaranteeToParams,
+} from '../test-helpers';
+import {HashZero} from 'ethers/constants';
+import {BigNumber} from 'ethers/utils';
+
+const provider = new ethers.providers.JsonRpcProvider(
+  `http://localhost:${process.env.DEV_GANACHE_PORT}`,
+);
+
+const I = ethers.Wallet.createRandom().address.padEnd(66, '0');
+const A = ethers.Wallet.createRandom().address.padEnd(66, '0');
+const B = ethers.Wallet.createRandom().address.padEnd(66, '0');
+let AssetHolder: ethers.Contract;
+let assetTransferredEvents;
+
+beforeAll(async () => {
+  AssetHolder = await setupContracts(provider, AssetHolderArtifact);
+});
+
+const description0 = 'Pays out correctly (straight-through guarantee)'; // figure 23 of nitro paper
+
+// amounts are valueString represenationa of wei
+describe('claimAll', () => {
+  it.each`
+    description     | cNonce | cDestBefore  | cAmountsBefore     | cDestAfter | cAmountsAfter | gNonce | guarantee    | gHeldBefore | gHeldAfter | outcomeSet      | payouts            | reasonString
+    ${description0} | ${0}   | ${[I, A, B]} | ${['5', '5', '5']} | ${[A, B]}  | ${['5', '5']} | ${100} | ${[I, A, B]} | ${'5'}      | ${'0'}     | ${[true, true]} | ${['5', '0', '0']} | ${undefined}
+  `(
+    '$description',
+    async ({
+      cNonce,
+      cDestBefore,
+      cAmountsBefore,
+      cDestAfter,
+      cAmountsAfter,
+      gNonce,
+      guarantee,
+      gHeldBefore,
+      gHeldAfter,
+      outcomeSet,
+      payouts,
+      reasonString,
+    }) => {
+      cAmountsBefore = cAmountsBefore.map(x => ethers.utils.parseUnits(x, 'wei'));
+      gHeldBefore = ethers.utils.parseUnits(gHeldBefore, 'wei');
+      gHeldAfter = ethers.utils.parseUnits(gHeldAfter, 'wei');
+      payouts = payouts.map(x => ethers.utils.parseUnits(x, 'wei')) as BigNumber[];
+
+      // compute channelIds
+      const channelId = randomChannelId(cNonce);
+      const guaranteeId = randomChannelId(gNonce);
+
+      // set holdings (only works on test contract)
+      if (gHeldBefore.gt(0)) {
+        await (await AssetHolder.setHoldings(guaranteeId, gHeldBefore)).wait();
+        expect(await AssetHolder.holdings(guaranteeId)).toEqual(gHeldBefore);
+      }
+
+      // compute an appropriate allocation
+      const allocation = cDestBefore.map((x, index, array) => ({
+        destination: x,
+        amount: cAmountsBefore[index],
+      }));
+
+      const [allocationBytes, outcomeHash] = allocationToParams(allocation);
+
+      // set outcomeHash
+      if (outcomeSet[0]) {
+        await (await AssetHolder.setOutcomePermissionless(channelId, outcomeHash)).wait();
+        expect(await AssetHolder.outcomeHashes(channelId)).toBe(outcomeHash);
+      }
+
+      // compute a guarantee
+      const [destinationsBytes, gOutcomeHash] = guaranteeToParams(guarantee);
+
+      if (outcomeSet[1]) {
+        await (await AssetHolder.setOutcomePermissionless(guaranteeId, gOutcomeHash)).wait();
+        expect(await AssetHolder.outcomeHashes(guaranteeId)).toBe(gOutcomeHash);
+      }
+
+      // call method in a slightly different way if expecting a revert
+      if (reasonString) {
+        const regex = new RegExp(
+          '^' + 'VM Exception while processing transaction: revert ' + reasonString + '$',
+        );
+        await expectRevert(
+          () => AssetHolder.claimAll(guaranteeId, channelId, destinationsBytes, allocationBytes),
+          regex,
+        );
+      } else {
+        // register for events
+        assetTransferredEvents = cDestBefore.map((x, index, array) => {
+          if (payouts[index].gt(0)) {
+            return newAssetTransferredEvent(AssetHolder, x);
+          }
+        });
+
+        // submit tx
+        const tx = await AssetHolder.claimAll(
+          guaranteeId,
+          channelId,
+          destinationsBytes,
+          allocationBytes,
+        );
+        // wait for tx to be mined
+        await tx.wait();
+
+        // catch events
+        const resolvedAassetTransferredEvents = await Promise.all(assetTransferredEvents);
+        resolvedAassetTransferredEvents.forEach(async (x, index, array) => {
+          if (payouts[index].gt(0)) {
+            expect(x).toEqual(payouts[index]);
+          }
+        });
+
+        // assume all beneficiaries are external so no holdings to update other than
+        expect(await AssetHolder.holdings(guaranteeId)).toEqual(gHeldAfter);
+
+        // check new outcomeHash
+        let expectedNewOutcomeHash;
+        let _;
+
+        if (cDestAfter.length > 0) {
+          // compute an appropriate allocation
+          const allocationAfter = cDestAfter.map((x, index, array) => ({
+            destination: x,
+            amount: cAmountsAfter[index],
+          }));
+
+          [_, expectedNewOutcomeHash] = allocationToParams(allocationAfter);
+        } else {
+          expectedNewOutcomeHash = HashZero;
+        }
+
+        expect(await AssetHolder.outcomeHashes(channelId)).toEqual(expectedNewOutcomeHash);
+      }
+    },
+  );
+});

--- a/test/AssetHolder/claimAll.test.ts
+++ b/test/AssetHolder/claimAll.test.ts
@@ -34,15 +34,19 @@ const description2 =
   'Pays out and updates holdings, outcomeHashes out correctly (swap guarantee, 3 destinations)'; // claim G1 (step 1 of alternative in figure 23 of nitro paper)
 const description3 =
   'Pays out and updates holdings, outcomeHashes correctly (straight-through guarantee, 2 destinations)'; // claim G2 (step 2 of alternative of figure 23 of nitro paper)
+const description4 = 'Reverts when allocation not on chain';
+const description5 = 'Reverts when guarantee not on chain';
 
 // amounts are valueString represenationa of wei
 describe('claimAll', () => {
   it.each`
-    description     | cNonce | cDestBefore  | cAmountsBefore     | cDestAfter | cAmountsAfter | gNonce | guarantee    | gHeldBefore | gHeldAfter | outcomeSet      | payouts            | reasonString
-    ${description0} | ${0}   | ${[I, A, B]} | ${['5', '5', '5']} | ${[A, B]}  | ${['5', '5']} | ${100} | ${[I, A, B]} | ${'5'}      | ${'0'}     | ${[true, true]} | ${['5', '0', '0']} | ${undefined}
-    ${description1} | ${1}   | ${[A, B]}    | ${['5', '5']}      | ${[A]}     | ${['5']}      | ${101} | ${[I, B, A]} | ${'5'}      | ${'0'}     | ${[true, true]} | ${['0', '5']}      | ${undefined}
-    ${description2} | ${0}   | ${[I, A, B]} | ${['5', '5', '5']} | ${[A, B]}  | ${['5', '5']} | ${100} | ${[I, B, A]} | ${'5'}      | ${'0'}     | ${[true, true]} | ${['5', '0', '0']} | ${undefined}
-    ${description3} | ${3}   | ${[A, B]}    | ${['5', '5']}      | ${[B]}     | ${['5']}      | ${103} | ${[I, A, B]} | ${'5'}      | ${'0'}     | ${[true, true]} | ${['5', '0']}      | ${undefined}
+    description     | cNonce | cDestBefore  | cAmountsBefore     | cDestAfter | cAmountsAfter | gNonce | guarantee    | gHeldBefore | gHeldAfter | outcomeSet       | payouts            | reasonString
+    ${description0} | ${0}   | ${[I, A, B]} | ${['5', '5', '5']} | ${[A, B]}  | ${['5', '5']} | ${100} | ${[I, A, B]} | ${'5'}      | ${'0'}     | ${[true, true]}  | ${['5', '0', '0']} | ${undefined}
+    ${description1} | ${1}   | ${[A, B]}    | ${['5', '5']}      | ${[A]}     | ${['5']}      | ${101} | ${[I, B, A]} | ${'5'}      | ${'0'}     | ${[true, true]}  | ${['0', '5']}      | ${undefined}
+    ${description2} | ${0}   | ${[I, A, B]} | ${['5', '5', '5']} | ${[A, B]}  | ${['5', '5']} | ${100} | ${[I, B, A]} | ${'5'}      | ${'0'}     | ${[true, true]}  | ${['5', '0', '0']} | ${undefined}
+    ${description3} | ${3}   | ${[A, B]}    | ${['5', '5']}      | ${[B]}     | ${['5']}      | ${103} | ${[I, A, B]} | ${'5'}      | ${'0'}     | ${[true, true]}  | ${['5', '0']}      | ${undefined}
+    ${description4} | ${3}   | ${[A, B]}    | ${['5', '5']}      | ${[B]}     | ${['5']}      | ${103} | ${[I, A, B]} | ${'5'}      | ${'0'}     | ${[false, true]} | ${['5', '0']}      | ${'claimAll | submitted data does not match outcomeHash stored against guaranteedChannelId'}
+    ${description5} | ${3}   | ${[A, B]}    | ${['5', '5']}      | ${[B]}     | ${['5']}      | ${103} | ${[I, A, B]} | ${'5'}      | ${'0'}     | ${[true, false]} | ${['5', '0']}      | ${'claimAll | submitted data does not match outcomeHash stored against channelId'}
   `(
     '$description',
     async ({

--- a/test/AssetHolder/claimAll.test.ts
+++ b/test/AssetHolder/claimAll.test.ts
@@ -26,13 +26,23 @@ beforeAll(async () => {
   AssetHolder = await setupContracts(provider, AssetHolderArtifact);
 });
 
-const description0 = 'Pays out correctly (straight-through guarantee)'; // figure 23 of nitro paper
+const description0 =
+  'Pays out and updates holdings, outcomeHashes correctly (straight-through guarantee, 3 destinations)'; // claim G1 (step 1 of figure 23 of nitro paper)
+const description1 =
+  'Pays out and updates holdings, outcomeHashes correctly (swap guarantee, 2 destinations)'; // claim G2 (step 2 of figure 23 of nitro paper)
+const description2 =
+  'Pays out and updates holdings, outcomeHashes out correctly (swap guarantee, 3 destinations)'; // claim G1 (step 1 of alternative in figure 23 of nitro paper)
+const description3 =
+  'Pays out and updates holdings, outcomeHashes correctly (straight-through guarantee, 2 destinations)'; // claim G2 (step 2 of alternative of figure 23 of nitro paper)
 
 // amounts are valueString represenationa of wei
 describe('claimAll', () => {
   it.each`
     description     | cNonce | cDestBefore  | cAmountsBefore     | cDestAfter | cAmountsAfter | gNonce | guarantee    | gHeldBefore | gHeldAfter | outcomeSet      | payouts            | reasonString
     ${description0} | ${0}   | ${[I, A, B]} | ${['5', '5', '5']} | ${[A, B]}  | ${['5', '5']} | ${100} | ${[I, A, B]} | ${'5'}      | ${'0'}     | ${[true, true]} | ${['5', '0', '0']} | ${undefined}
+    ${description1} | ${1}   | ${[A, B]}    | ${['5', '5']}      | ${[A]}     | ${['5']}      | ${101} | ${[I, B, A]} | ${'5'}      | ${'0'}     | ${[true, true]} | ${['0', '5']}      | ${undefined}
+    ${description2} | ${0}   | ${[I, A, B]} | ${['5', '5', '5']} | ${[A, B]}  | ${['5', '5']} | ${100} | ${[I, B, A]} | ${'5'}      | ${'0'}     | ${[true, true]} | ${['5', '0', '0']} | ${undefined}
+    ${description3} | ${3}   | ${[A, B]}    | ${['5', '5']}      | ${[B]}     | ${['5']}      | ${103} | ${[I, A, B]} | ${'5'}      | ${'0'}     | ${[true, true]} | ${['5', '0']}      | ${undefined}
   `(
     '$description',
     async ({

--- a/test/AssetHolder/transferAll.test.ts
+++ b/test/AssetHolder/transferAll.test.ts
@@ -2,8 +2,12 @@ import {ethers} from 'ethers';
 import {expectRevert} from 'magmo-devtools';
 // @ts-ignore
 import AssetHolderArtifact from '../../build/contracts/TESTAssetHolder.json';
-import {setupContracts, newAssetTransferredEvent, randomChannelId} from '../test-helpers';
-import {defaultAbiCoder, keccak256} from 'ethers/utils';
+import {
+  setupContracts,
+  newAssetTransferredEvent,
+  randomChannelId,
+  allocationToParams,
+} from '../test-helpers';
 import {HashZero} from 'ethers/constants';
 
 const provider = new ethers.providers.JsonRpcProvider(
@@ -18,20 +22,6 @@ let assetTransferredEvent;
 let assetTransferredEvent0;
 let assetTransferredEvent1;
 const participants = ['', '', ''];
-
-function allocationToParams(allocation) {
-  const allocationBytes = defaultAbiCoder.encode(
-    ['tuple(bytes32 destination, uint256 amount)[]'],
-    [allocation],
-  );
-  const labelledAllocationOrGuarantee = [0, allocationBytes];
-  const outcomeContent = defaultAbiCoder.encode(
-    ['tuple(uint8, bytes)'],
-    [labelledAllocationOrGuarantee],
-  );
-  const outcomeHash = keccak256(outcomeContent);
-  return [allocationBytes, outcomeHash];
-}
 
 beforeAll(async () => {
   AssetHolder = await setupContracts(provider, AssetHolderArtifact);

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -149,3 +149,28 @@ export function randomChannelId(channelNonce = 0) {
   );
   return channelId;
 }
+
+export function allocationToParams(allocation) {
+  const allocationBytes = defaultAbiCoder.encode(
+    ['tuple(bytes32 destination, uint256 amount)[]'],
+    [allocation],
+  );
+  const labelledAllocationOrGuarantee = [0, allocationBytes];
+  const outcomeContent = defaultAbiCoder.encode(
+    ['tuple(uint8, bytes)'],
+    [labelledAllocationOrGuarantee],
+  );
+  const outcomeHash = keccak256(outcomeContent);
+  return [allocationBytes, outcomeHash];
+}
+
+export function guaranteeToParams(guarantee) {
+  const destinationsBytes = defaultAbiCoder.encode(['bytes32[]'], [guarantee]);
+  const labelledAllocationOrGuarantee = [1, destinationsBytes];
+  const outcomeContent = defaultAbiCoder.encode(
+    ['tuple(uint8, bytes)'],
+    [labelledAllocationOrGuarantee],
+  );
+  const outcomeHash = keccak256(outcomeContent);
+  return [destinationsBytes, outcomeHash];
+}


### PR DESCRIPTION
This PR adds `claimAll` -- the final remaining external method for nitro protocol -- to the `AssetHolder` base contract.

TODO list

- [x] compiling/deploying solidity implementation
- [x] single test passing (straight-through guarantee) 46K gas
- [x] more tests, including figure 23 of the [nitro whitepaper](https://magmo.com/nitro-protocol.pdf)

test coverage:
 
<img width="699" alt="Screenshot 2019-09-06 at 14 08 52" src="https://user-images.githubusercontent.com/1833419/64430284-df8e2600-d0af-11e9-976d-49782e8a1fc7.png">


Ideas for further work:
- Convert `transferAll.test.ts` to follow the same pattern as `claimAll.test.ts` -- will make it much easier to add test cases.
- Use stricter terminology throughout tests and contracts: e.g. avoid potential confusion around `guarantee` vs `guaranteeChannel` vs `guaranteedChannel`

