### PR TITLE
Tidy up test for transferAll

### DIFF
--- a/test/AssetHolder/claimAll.test.ts
+++ b/test/AssetHolder/claimAll.test.ts
@@ -21,7 +21,6 @@ const I = ethers.Wallet.createRandom().address.padEnd(66, '0');
 const A = ethers.Wallet.createRandom().address.padEnd(66, '0');
 const B = ethers.Wallet.createRandom().address.padEnd(66, '0');
 let AssetHolder: ethers.Contract;
-let assetTransferredEvents;
 
 beforeAll(async () => {
   AssetHolder = await setupContracts(provider, AssetHolderArtifact);
@@ -115,7 +114,7 @@ describe('claimAll', () => {
         );
       } else {
         // register for events
-        assetTransferredEvents = cDestBefore.map((x, index, array) => {
+        const assetTransferredEvents = cDestBefore.map((x, index, array) => {
           if (payouts[index].gt(0)) {
             return newAssetTransferredEvent(AssetHolder, x);
           }

--- a/test/AssetHolder/transferAll.test.ts
+++ b/test/AssetHolder/transferAll.test.ts
@@ -17,9 +17,8 @@ const provider = new ethers.providers.JsonRpcProvider(
 let AssetHolder: ethers.Contract;
 
 // channels
-const [C4, C5, C6, C7, C8, C9, X7, X8, X9] = Array(9)
-  .fill(undefined)
-  .map(randomChannelId);
+const C = randomChannelId();
+const X = randomChannelId();
 
 // externals
 const A = ethers.Wallet.createRandom().address.padEnd(66, '0');
@@ -29,26 +28,26 @@ beforeAll(async () => {
   AssetHolder = await setupContracts(provider, AssetHolderArtifact);
 });
 
-const description0 = '0. Reverts transferAll tx when outcomeHash does not match';
+const description0 = ' 0. Reverts transferAll tx when outcomeHash does not match';
 const reason1 = 'transferAll | submitted data does not match stored outcomeHash';
 const description1 =
-  '1. Pays out all holdings from directly-funded channel allocating to a single external address';
+  ' 1. Pays out all holdings from directly-funded channel allocating to a single external address';
 const description2 =
-  '2. Pays out some of the holdings when directly-overfunded channel allocates assets to a single external address';
+  ' 2. Pays out some of the holdings when directly-overfunded channel allocates assets to a single external address';
 const description3 =
-  '3. Pays out all of the holdings when directly-underfunded channel allocates assets to a single external address';
+  ' 3. Pays out all of the holdings when directly-underfunded channel allocates assets to a single external address';
 const description4 =
-  '4. Transfers all holdings from directly-funded channel allocating to a single channel';
+  ' 4. Transfers all holdings from directly-funded channel allocating to a single channel';
 const description5 =
-  '5. Transfers all holdings from directly-overfunded channel allocating to a single channel';
+  ' 5. Transfers all holdings from directly-overfunded channel allocating to a single channel';
 const description6 =
-  '6. Transfers all holdings from directly-underfunded channel allocating to a single channel';
+  ' 6. Transfers all holdings from directly-underfunded channel allocating to a single channel';
 const description7 =
-  '7. Transfers all holdings from directly-funded channel allocating to two external addresses (full payout, full payout)';
+  ' 7. Transfers all holdings from directly-funded channel allocating to two external addresses (full payout, full payout)';
 const description8 =
-  '8. Transfers all holdings from directly-funded channel allocating to two external addresses (full payout, no payout)';
+  ' 8. Transfers all holdings from directly-funded channel allocating to two external addresses (full payout, no payout)';
 const description9 =
-  '9. Transfers all holdings from directly-funded channel allocating to two external addresses (full payout, partial payout)';
+  ' 9. Transfers all holdings from directly-funded channel allocating to two external addresses (full payout, partial payout)';
 const description10 =
   '10. Transfers all holdings from directly-funded channel allocating to two channels (full payout, full payout)';
 const description11 =
@@ -59,20 +58,20 @@ const description12 =
 // amounts are valueString represenationa of wei
 describe('transferAll', () => {
   it.each`
-    description      | nonce | outcomeSet | held   | destBefore  | amountsBefore | destAfter | amountsAfter | heldAfterId | heldAfterAmounts | payouts       | heldAfter | reasonString
-    ${description0}  | ${0}  | ${false}   | ${'1'} | ${[A]}      | ${['1']}      | ${[]}     | ${[]}        | ${[]}       | ${[]}            | ${[]}         | ${'0'}    | ${reason1}
-    ${description1}  | ${1}  | ${true}    | ${'1'} | ${[A]}      | ${['1']}      | ${[]}     | ${[]}        | ${[]}       | ${[]}            | ${[]}         | ${'0'}    | ${undefined}
-    ${description2}  | ${2}  | ${true}    | ${'2'} | ${[A]}      | ${['1']}      | ${[]}     | ${[]}        | ${[]}       | ${[]}            | ${['1']}      | ${'1'}    | ${undefined}
-    ${description3}  | ${3}  | ${true}    | ${'1'} | ${[A]}      | ${['2']}      | ${[A]}    | ${['1']}     | ${[]}       | ${[]}            | ${['1']}      | ${'0'}    | ${undefined}
-    ${description4}  | ${4}  | ${true}    | ${'1'} | ${[C4]}     | ${['1']}      | ${[]}     | ${[]}        | ${[C4]}     | ${['1']}         | ${[]}         | ${'0'}    | ${undefined}
-    ${description5}  | ${5}  | ${true}    | ${'2'} | ${[C5]}     | ${['1']}      | ${[]}     | ${[]}        | ${[C5]}     | ${['1']}         | ${[]}         | ${'1'}    | ${undefined}
-    ${description6}  | ${6}  | ${true}    | ${'1'} | ${[C6]}     | ${['2']}      | ${[C6]}   | ${['1']}     | ${[C6]}     | ${['1']}         | ${[]}         | ${'0'}    | ${undefined}
-    ${description7}  | ${7}  | ${true}    | ${'2'} | ${[A, B]}   | ${['1', '1']} | ${[]}     | ${[]}        | ${[]}       | ${[]}            | ${['1', '1']} | ${'0'}    | ${undefined}
-    ${description8}  | ${8}  | ${true}    | ${'1'} | ${[A, B]}   | ${['1', '1']} | ${[B]}    | ${['1']}     | ${[]}       | ${[]}            | ${['1']}      | ${'0'}    | ${undefined}
-    ${description9}  | ${9}  | ${true}    | ${'3'} | ${[A, B]}   | ${['2', '2']} | ${[B]}    | ${['1']}     | ${[]}       | ${[]}            | ${['2', '1']} | ${'0'}    | ${undefined}
-    ${description10} | ${10} | ${true}    | ${'2'} | ${[C7, X7]} | ${['1', '1']} | ${[]}     | ${[]}        | ${[C7, X7]} | ${['1', '1']}    | ${[]}         | ${'0'}    | ${undefined}
-    ${description11} | ${11} | ${true}    | ${'1'} | ${[C8, X8]} | ${['1', '1']} | ${[X8]}   | ${['1']}     | ${[C8]}     | ${['1']}         | ${[]}         | ${'0'}    | ${undefined}
-    ${description12} | ${12} | ${true}    | ${'3'} | ${[C9, X9]} | ${['2', '2']} | ${[X9]}   | ${['1']}     | ${[C9, X9]} | ${['2', '1']}    | ${[]}         | ${'0'}    | ${undefined}
+    description      | nonce | outcomeSet | held   | destBefore | amountsBefore | destAfter | amountsAfter | heldAfterId | heldAfterAmounts | payouts       | heldAfter | reasonString
+    ${description0}  | ${0}  | ${false}   | ${'1'} | ${[A]}     | ${['1']}      | ${[]}     | ${[]}        | ${[]}       | ${[]}            | ${[]}         | ${'0'}    | ${reason1}
+    ${description1}  | ${1}  | ${true}    | ${'1'} | ${[A]}     | ${['1']}      | ${[]}     | ${[]}        | ${[]}       | ${[]}            | ${[]}         | ${'0'}    | ${undefined}
+    ${description2}  | ${2}  | ${true}    | ${'2'} | ${[A]}     | ${['1']}      | ${[]}     | ${[]}        | ${[]}       | ${[]}            | ${['1']}      | ${'1'}    | ${undefined}
+    ${description3}  | ${3}  | ${true}    | ${'1'} | ${[A]}     | ${['2']}      | ${[A]}    | ${['1']}     | ${[]}       | ${[]}            | ${['1']}      | ${'0'}    | ${undefined}
+    ${description4}  | ${4}  | ${true}    | ${'1'} | ${[C]}     | ${['1']}      | ${[]}     | ${[]}        | ${[C]}      | ${['1']}         | ${[]}         | ${'0'}    | ${undefined}
+    ${description5}  | ${5}  | ${true}    | ${'2'} | ${[C]}     | ${['1']}      | ${[]}     | ${[]}        | ${[C]}      | ${['1']}         | ${[]}         | ${'1'}    | ${undefined}
+    ${description6}  | ${6}  | ${true}    | ${'1'} | ${[C]}     | ${['2']}      | ${[C]}    | ${['1']}     | ${[C]}      | ${['1']}         | ${[]}         | ${'0'}    | ${undefined}
+    ${description7}  | ${7}  | ${true}    | ${'2'} | ${[A, B]}  | ${['1', '1']} | ${[]}     | ${[]}        | ${[]}       | ${[]}            | ${['1', '1']} | ${'0'}    | ${undefined}
+    ${description8}  | ${8}  | ${true}    | ${'1'} | ${[A, B]}  | ${['1', '1']} | ${[B]}    | ${['1']}     | ${[]}       | ${[]}            | ${['1']}      | ${'0'}    | ${undefined}
+    ${description9}  | ${9}  | ${true}    | ${'3'} | ${[A, B]}  | ${['2', '2']} | ${[B]}    | ${['1']}     | ${[]}       | ${[]}            | ${['2', '1']} | ${'0'}    | ${undefined}
+    ${description10} | ${10} | ${true}    | ${'2'} | ${[C, X]}  | ${['1', '1']} | ${[]}     | ${[]}        | ${[C, X]}   | ${['1', '1']}    | ${[]}         | ${'0'}    | ${undefined}
+    ${description11} | ${11} | ${true}    | ${'1'} | ${[C, X]}  | ${['1', '1']} | ${[X]}    | ${['1']}     | ${[C]}      | ${['1']}         | ${[]}         | ${'0'}    | ${undefined}
+    ${description12} | ${12} | ${true}    | ${'3'} | ${[C, X]}  | ${['2', '2']} | ${[X]}    | ${['1']}     | ${[C, X]}   | ${['2', '1']}    | ${[]}         | ${'0'}    | ${undefined}
   `(
     '$description',
     async ({

--- a/test/AssetHolder/transferAll.test.ts
+++ b/test/AssetHolder/transferAll.test.ts
@@ -44,26 +44,35 @@ const description5 =
 const description6 =
   '6. Transfers all holdings from directly-underfunded channel allocating to a single channel';
 const description7 =
-  '7. Transfers all holdings from directly-funded channel allocating to two channels (full payout, full payout)';
+  '7. Transfers all holdings from directly-funded channel allocating to two external addresses (full payout, full payout)';
 const description8 =
-  '8. Transfers all holdings from directly-funded channel allocating to two channels (full payout, no payout)';
+  '8. Transfers all holdings from directly-funded channel allocating to two external addresses (full payout, no payout)';
 const description9 =
-  '9. Transfers all holdings from directly-funded channel allocating to two channels (full payout, partial payout)';
+  '9. Transfers all holdings from directly-funded channel allocating to two external addresses (full payout, partial payout)';
+const description10 =
+  '10. Transfers all holdings from directly-funded channel allocating to two channels (full payout, full payout)';
+const description11 =
+  '11. Transfers all holdings from directly-funded channel allocating to two channels (full payout, no payout)';
+const description12 =
+  '12. Transfers all holdings from directly-funded channel allocating to two channels (full payout, partial payout)';
 
 // amounts are valueString represenationa of wei
 describe('transferAll', () => {
   it.each`
-    description     | nonce | outcomeSet | held   | destBefore  | amountsBefore | destAfter | amountsAfter | heldAfterId | heldAfterAmounts | payouts  | heldAfter | reasonString
-    ${description0} | ${0}  | ${false}   | ${'1'} | ${[A]}      | ${['1']}      | ${[]}     | ${[]}        | ${[]}       | ${[]}            | ${[]}    | ${'0'}    | ${reason1}
-    ${description1} | ${1}  | ${true}    | ${'1'} | ${[A]}      | ${['1']}      | ${[]}     | ${[]}        | ${[]}       | ${[]}            | ${[]}    | ${'0'}    | ${undefined}
-    ${description2} | ${2}  | ${true}    | ${'2'} | ${[A]}      | ${['1']}      | ${[]}     | ${[]}        | ${[]}       | ${[]}            | ${['1']} | ${'1'}    | ${undefined}
-    ${description3} | ${3}  | ${true}    | ${'1'} | ${[A]}      | ${['2']}      | ${[A]}    | ${['1']}     | ${[]}       | ${[]}            | ${['1']} | ${'0'}    | ${undefined}
-    ${description4} | ${4}  | ${true}    | ${'1'} | ${[C4]}     | ${['1']}      | ${[]}     | ${[]}        | ${[C4]}     | ${['1']}         | ${[]}    | ${'0'}    | ${undefined}
-    ${description5} | ${5}  | ${true}    | ${'2'} | ${[C5]}     | ${['1']}      | ${[]}     | ${[]}        | ${[C5]}     | ${['1']}         | ${[]}    | ${'1'}    | ${undefined}
-    ${description6} | ${6}  | ${true}    | ${'1'} | ${[C6]}     | ${['2']}      | ${[C6]}   | ${['1']}     | ${[C6]}     | ${['1']}         | ${[]}    | ${'0'}    | ${undefined}
-    ${description7} | ${7}  | ${true}    | ${'2'} | ${[C7, X7]} | ${['1', '1']} | ${[]}     | ${[]}        | ${[C7, X7]} | ${['1', '1']}    | ${[]}    | ${'0'}    | ${undefined}
-    ${description8} | ${8}  | ${true}    | ${'1'} | ${[C8, X8]} | ${['1', '1']} | ${[X8]}   | ${['1']}     | ${[C8]}     | ${['1']}         | ${[]}    | ${'0'}    | ${undefined}
-    ${description9} | ${9}  | ${true}    | ${'3'} | ${[C9, X9]} | ${['2', '2']} | ${[X9]}   | ${['1']}     | ${[C9, X9]} | ${['2', '1']}    | ${[]}    | ${'0'}    | ${undefined}
+    description      | nonce | outcomeSet | held   | destBefore  | amountsBefore | destAfter | amountsAfter | heldAfterId | heldAfterAmounts | payouts       | heldAfter | reasonString
+    ${description0}  | ${0}  | ${false}   | ${'1'} | ${[A]}      | ${['1']}      | ${[]}     | ${[]}        | ${[]}       | ${[]}            | ${[]}         | ${'0'}    | ${reason1}
+    ${description1}  | ${1}  | ${true}    | ${'1'} | ${[A]}      | ${['1']}      | ${[]}     | ${[]}        | ${[]}       | ${[]}            | ${[]}         | ${'0'}    | ${undefined}
+    ${description2}  | ${2}  | ${true}    | ${'2'} | ${[A]}      | ${['1']}      | ${[]}     | ${[]}        | ${[]}       | ${[]}            | ${['1']}      | ${'1'}    | ${undefined}
+    ${description3}  | ${3}  | ${true}    | ${'1'} | ${[A]}      | ${['2']}      | ${[A]}    | ${['1']}     | ${[]}       | ${[]}            | ${['1']}      | ${'0'}    | ${undefined}
+    ${description4}  | ${4}  | ${true}    | ${'1'} | ${[C4]}     | ${['1']}      | ${[]}     | ${[]}        | ${[C4]}     | ${['1']}         | ${[]}         | ${'0'}    | ${undefined}
+    ${description5}  | ${5}  | ${true}    | ${'2'} | ${[C5]}     | ${['1']}      | ${[]}     | ${[]}        | ${[C5]}     | ${['1']}         | ${[]}         | ${'1'}    | ${undefined}
+    ${description6}  | ${6}  | ${true}    | ${'1'} | ${[C6]}     | ${['2']}      | ${[C6]}   | ${['1']}     | ${[C6]}     | ${['1']}         | ${[]}         | ${'0'}    | ${undefined}
+    ${description7}  | ${7}  | ${true}    | ${'2'} | ${[A, B]}   | ${['1', '1']} | ${[]}     | ${[]}        | ${[]}       | ${[]}            | ${['1', '1']} | ${'0'}    | ${undefined}
+    ${description8}  | ${8}  | ${true}    | ${'1'} | ${[A, B]}   | ${['1', '1']} | ${[B]}    | ${['1']}     | ${[]}       | ${[]}            | ${['1']}      | ${'0'}    | ${undefined}
+    ${description9}  | ${9}  | ${true}    | ${'3'} | ${[A, B]}   | ${['2', '2']} | ${[B]}    | ${['1']}     | ${[]}       | ${[]}            | ${['2', '1']} | ${'0'}    | ${undefined}
+    ${description10} | ${10} | ${true}    | ${'2'} | ${[C7, X7]} | ${['1', '1']} | ${[]}     | ${[]}        | ${[C7, X7]} | ${['1', '1']}    | ${[]}         | ${'0'}    | ${undefined}
+    ${description11} | ${11} | ${true}    | ${'1'} | ${[C8, X8]} | ${['1', '1']} | ${[X8]}   | ${['1']}     | ${[C8]}     | ${['1']}         | ${[]}         | ${'0'}    | ${undefined}
+    ${description12} | ${12} | ${true}    | ${'3'} | ${[C9, X9]} | ${['2', '2']} | ${[X9]}   | ${['1']}     | ${[C9, X9]} | ${['2', '1']}    | ${[]}         | ${'0'}    | ${undefined}
   `(
     '$description',
     async ({


### PR DESCRIPTION
Introducing a single, new testing scheme (`A` and `B` are external addresses, `C` and `X` are channel addresses): 
<img width="838" alt="Screenshot 2019-09-06 at 16 36 43" src="https://user-images.githubusercontent.com/1833419/64441033-fdb25100-d0c4-11e9-8467-4b14a9ec50a4.png">
