### PR TITLE
Add typescript interfaces and functions

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,4 @@
 contracts/AssetHolder.sol
+# NitroAdjudicator fails to get parsed properly by prettier for some reason
+# Ignoring for now until it's fixed
+contracts/NitroAdjudicator.sol

--- a/contracts/AssetHolder.sol
+++ b/contracts/AssetHolder.sol
@@ -102,15 +102,15 @@ contract AssetHolder {
 
     }
 
-    function claimAll(bytes32 channelId, bytes32 guaranteedChannelId, bytes calldata guaranteeBytes, bytes calldata allocationBytes) external {
+    function claimAll(bytes32 channelId, bytes calldata guaranteeBytes, bytes calldata allocationBytes) external {
         // requirements
 
         require(
             outcomeHashes[channelId] ==
                 keccak256(
                     abi.encode(
-                        Outcome.LabelledAllocationOrGuarantee(
-                            uint8(Outcome.OutcomeType.Guarantee),
+                       Outcome.LabelledAllocationOrGuarantee(
+                           uint8(Outcome.OutcomeType.Guarantee),
                             guaranteeBytes
                         )
                     )
@@ -118,8 +118,11 @@ contract AssetHolder {
             'claimAll | submitted data does not match outcomeHash stored against channelId'
         );
 
+        Outcome.Guarantee memory guarantee = abi.decode(guaranteeBytes,(Outcome.Guarantee));
+        
+  
         require(
-            outcomeHashes[guaranteedChannelId] ==
+            outcomeHashes[guarantee.guaranteedChannelId] ==
                 keccak256(
                     abi.encode(
                         Outcome.LabelledAllocationOrGuarantee(
@@ -134,7 +137,7 @@ contract AssetHolder {
         uint256 balance = holdings[channelId];
 
         Outcome.AllocationItem[] memory allocation = abi.decode(allocationBytes,(Outcome.AllocationItem[])); // this remains constant length
-        Outcome.Guarantee memory guarantee = abi.decode(guaranteeBytes,(Outcome.Guarantee));
+
         uint256[] memory payouts = new uint256[](allocation.length);
         uint256 newAllocationLength = allocation.length;
 
@@ -213,7 +216,7 @@ contract AssetHolder {
 
         if (newAllocationLength > 0) {
             // store hash
-            outcomeHashes[guaranteedChannelId] = keccak256(abi.encode(
+            outcomeHashes[guarantee.guaranteedChannelId] = keccak256(abi.encode(
                 Outcome.LabelledAllocationOrGuarantee(
                             uint8(Outcome.OutcomeType.Allocation),
                             abi.encode(newAllocation)

--- a/contracts/AssetHolder.sol
+++ b/contracts/AssetHolder.sol
@@ -102,7 +102,7 @@ contract AssetHolder {
 
     }
 
-    function claimAll(bytes32 channelId, bytes32 guaranteedChannelId, bytes calldata destinationsBytes, bytes calldata allocationBytes) external {
+    function claimAll(bytes32 channelId, bytes32 guaranteedChannelId, bytes calldata guaranteeBytes, bytes calldata allocationBytes) external {
         // requirements
 
         require(
@@ -111,7 +111,7 @@ contract AssetHolder {
                     abi.encode(
                         Outcome.LabelledAllocationOrGuarantee(
                             uint8(Outcome.OutcomeType.Guarantee),
-                            destinationsBytes
+                            guaranteeBytes
                         )
                     )
                 ),
@@ -134,13 +134,13 @@ contract AssetHolder {
         uint256 balance = holdings[channelId];
 
         Outcome.AllocationItem[] memory allocation = abi.decode(allocationBytes,(Outcome.AllocationItem[])); // this remains constant length
-        bytes32[] memory destinations = abi.decode(destinationsBytes,(bytes32[]));
+        Outcome.Guarantee memory guarantee = abi.decode(guaranteeBytes,(Outcome.Guarantee));
         uint256[] memory payouts = new uint256[](allocation.length);
         uint256 newAllocationLength = allocation.length;
 
         // first increase payouts according to guarantee
-        for (uint256 i = 0; i < destinations.length; i++) { // for each destination in the guarantee
-            bytes32 _destination = destinations[i];
+        for (uint256 i = 0; i < guarantee.destinations.length; i++) { // for each destination in the guarantee
+            bytes32 _destination = guarantee.destinations[i];
             if (balance == 0) {
                 break;
             }

--- a/contracts/NitroAdjudicator.sol
+++ b/contracts/NitroAdjudicator.sol
@@ -16,12 +16,12 @@ contract NitroAdjudicator is ForceMove {
         uint256 finalizesAt,
         bytes32 stateHash,
         address challengerAddress,
-        bytes memory assetOutcomeBytes
+        bytes memory outcome
     ) public {
         // requirements
         require(finalizesAt < now, 'Outcome is not final');
 
-        bytes32 outcomeHash = keccak256(assetOutcomeBytes);
+        bytes32 outcomeHash = keccak256(abi.encode(outcome));
 
         require(
             keccak256(
@@ -39,18 +39,16 @@ contract NitroAdjudicator is ForceMove {
             'Submitted data does not match storage'
         );
 
-        // effects
-        bytes[] memory assetOutcomes = abi.decode(assetOutcomeBytes, (bytes[]));
+         Outcome.AssetOutcome[] memory assetOutcomes = abi.decode(
+            outcome,
+            (Outcome.AssetOutcome[])
+        );
 
         for (uint256 i = 0; i < assetOutcomes.length; i++) {
-            Outcome.AssetOutcome memory assetOutcome = abi.decode(
-                assetOutcomes[i],
-                (Outcome.AssetOutcome)
-            );
             require(
-                AssetHolder(assetOutcome.assetHolderAddress).setOutcome(
+                AssetHolder(assetOutcomes[i].assetHolderAddress).setOutcome(
                     channelId,
-                    keccak256(assetOutcome.outcomeContent)
+                    keccak256(assetOutcomes[i].outcomeContent)
                 )
             );
         }

--- a/contracts/Outcome.sol
+++ b/contracts/Outcome.sol
@@ -30,7 +30,7 @@ library Outcome {
     }
 
     struct Guarantee {
-        address guaranteedChannelId;
+        bytes32 guaranteedChannelId;
         bytes32[] destinations;
     }
 

--- a/contracts/Outcome.sol
+++ b/contracts/Outcome.sol
@@ -31,7 +31,7 @@ library Outcome {
 
     struct Guarantee {
         address guaranteedChannelId;
-        address[] destinations;
+        bytes32[] destinations;
     }
 
 }

--- a/src/challenge.ts
+++ b/src/challenge.ts
@@ -1,0 +1,15 @@
+import {Bytes32, Uint256} from './types';
+import {keccak256, defaultAbiCoder} from 'ethers/utils';
+
+export function hashChallengeMessage(challengeMessage: {
+  largestTurnNum: Uint256;
+  channelId: Bytes32;
+}): Bytes32 {
+  const {largestTurnNum, channelId} = challengeMessage;
+  return keccak256(
+    defaultAbiCoder.encode(
+      ['uint256', 'uint256', 'string'],
+      [largestTurnNum, channelId, 'forceMove'],
+    ),
+  );
+}

--- a/src/channel-storage.ts
+++ b/src/channel-storage.ts
@@ -1,0 +1,48 @@
+import {Uint256, Bytes32, Address} from './types';
+import {defaultAbiCoder, keccak256} from 'ethers/utils';
+import {Outcome, hashOutcome} from './outcome';
+import {State, hashState} from './state';
+import {HashZero} from 'ethers/constants';
+
+export interface ChannelStorage {
+  largestTurnNum: Uint256;
+  finalizesAt: Uint256;
+  state?: State;
+  challengerAddress: Address;
+  outcome?: Outcome;
+}
+
+export interface ChannelStorageLite {
+  finalizesAt: Uint256;
+  state: State;
+  challengerAddress: Address;
+  outcome: Outcome;
+}
+
+export function hashChannelStorage(channelStorage: ChannelStorage): Bytes32 {
+  const outcomeHash = channelStorage.outcome ? hashOutcome(channelStorage.outcome) : HashZero;
+  const stateHash = channelStorage.state ? hashState(channelStorage.state) : HashZero;
+  const {largestTurnNum, finalizesAt, challengerAddress} = channelStorage;
+
+  return keccak256(
+    defaultAbiCoder.encode(
+      ['uint256', 'uint256', 'bytes32', 'address', 'bytes32'],
+      [largestTurnNum, finalizesAt, stateHash, challengerAddress, outcomeHash],
+    ),
+  );
+}
+
+export function encodeChannelStorageLite(channelStorageLite: ChannelStorageLite): Bytes32 {
+  const outcomeHash = channelStorageLite.outcome
+    ? hashOutcome(channelStorageLite.outcome)
+    : HashZero;
+  const stateHash = channelStorageLite.state ? hashState(channelStorageLite.state) : HashZero;
+  const {finalizesAt, challengerAddress} = channelStorageLite;
+
+  return defaultAbiCoder.encode(
+    [
+      'tuple(uint256 finalizesAt, bytes32 stateHash, address challengerAddress, bytes32 outcomeHash)',
+    ],
+    [[finalizesAt, stateHash, challengerAddress, outcomeHash]],
+  );
+}

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1,0 +1,18 @@
+import {Uint256, Address, Bytes32} from './types';
+import {defaultAbiCoder, keccak256} from 'ethers/utils';
+
+export interface Channel {
+  channelNonce: Uint256;
+  participants: Address[];
+  chainId: Uint256;
+}
+
+export function getChannelId(channel: Channel): Bytes32 {
+  const {chainId, participants, channelNonce} = channel;
+  return keccak256(
+    defaultAbiCoder.encode(
+      ['uint256', 'address[]', 'uint256'],
+      [chainId, participants, channelNonce],
+    ),
+  );
+}

--- a/src/outcome.ts
+++ b/src/outcome.ts
@@ -72,13 +72,13 @@ export function encodeOutcome(outcome: Outcome): Bytes32 {
 
 // Guarantee and functions
 export interface Guarantee {
-  guaranteedChannelAddress: Address;
+  guaranteedChannelAddress: Bytes32;
   destinations: Bytes32[];
 }
 
 export function encodeGuarantee(guarantee: Guarantee): Bytes32 {
   return defaultAbiCoder.encode(
-    ['tuple(uint8 guaranteedChannelId, bytes32[] destinations)'],
+    ['tuple(bytes32 guaranteedChannelId, bytes32[] destinations)'],
     [[guarantee.guaranteedChannelAddress, guarantee.destinations]],
   );
 }

--- a/src/outcome.ts
+++ b/src/outcome.ts
@@ -1,73 +1,9 @@
 import {defaultAbiCoder, keccak256} from 'ethers/utils';
 import {Bytes32, Address, Uint256} from './types';
 
-const ALLOCATION_OUTCOME = 0;
-const GUARANTEE_OUTCOME = 1;
-
-// Guarantee Outcome and functions
-export interface GuaranteeOutcome {
-  assetHolderAddress: Address;
-  guarantee: Guarantee;
-}
-
-export function isGuaranteeOutcome(assetOutcome: AssetOutcome): assetOutcome is GuaranteeOutcome {
-  return 'guarantee' in assetOutcome;
-}
-
-// This returns an encoded AssetOutcome
-export function encodeGuaranteeOutcome(guaranteeOutcome: GuaranteeOutcome): Bytes32 {
-  const guarantee = encodeGuarantee(guaranteeOutcome.guarantee);
-  return defaultAbiCoder.encode(
-    ['tuple(uint8 outcomeType, bytes allocationOrGuarantee)'],
-    [{outcomeType: GUARANTEE_OUTCOME, allocationOrGuarantee: guarantee}],
-  );
-}
-
-// Allocation outcome and functions
-export interface AllocationOutcome {
-  assetHolderAddress: Address;
-  allocation: AllocationItem[];
-}
-
-export function isAllocationOutcome(assetOutcome: AssetOutcome): assetOutcome is AllocationOutcome {
-  return 'allocation' in assetOutcome;
-}
-
-export function encodeAllocationOutcome(allocationOutcome: AllocationOutcome): Bytes32 {
-  const allocation = encodeAllocation(allocationOutcome.allocation);
-  return defaultAbiCoder.encode(
-    ['tuple(uint8 outcomeType, bytes allocationOrGuarantee)'],
-    [{outcomeType: ALLOCATION_OUTCOME, allocationOrGuarantee: allocation}],
-  );
-}
-export type AssetOutcome = AllocationOutcome | GuaranteeOutcome;
-
-export type Outcome = AssetOutcome[];
-
-export function hashOutcome(outcome: Outcome): Bytes32 {
-  const encodedOutcome = encodeOutcome(outcome);
-
-  return keccak256(defaultAbiCoder.encode(['bytes'], [encodedOutcome]));
-}
-
-export function hashOutcomeContent(assetOutcome: AssetOutcome): Bytes32 {
-  return keccak256(encodeOutcomeContent(assetOutcome));
-}
-function encodeOutcomeContent(assetOutcome: AssetOutcome): Bytes32 {
-  return isAllocationOutcome(assetOutcome)
-    ? encodeAllocationOutcome(assetOutcome)
-    : encodeGuaranteeOutcome(assetOutcome);
-}
-export function encodeOutcome(outcome: Outcome): Bytes32 {
-  const encodedAssetOutcomes = outcome.map(o => ({
-    assetHolderAddress: o.assetHolderAddress,
-    outcomeContent: encodeOutcomeContent(o),
-  }));
-
-  return defaultAbiCoder.encode(
-    ['tuple(address assetHolderAddress, bytes outcomeContent)[]'],
-    [encodedAssetOutcomes],
-  );
+export enum OutcomeType {
+  AllocationOutcomeType = 0,
+  GuaranteeOutcomeType = 1,
 }
 
 // Guarantee and functions
@@ -82,10 +18,14 @@ export function encodeGuarantee(guarantee: Guarantee): Bytes32 {
     [[guarantee.guaranteedChannelAddress, guarantee.destinations]],
   );
 }
+export function isGuarantee(
+  allocationOrGuarantee: Allocation | Guarantee,
+): allocationOrGuarantee is Guarantee {
+  return !isAllocation(allocationOrGuarantee);
+}
 
 // Allocation and functions
 export type Allocation = AllocationItem[];
-
 export interface AllocationItem {
   destination: Bytes32;
   amount: Uint256;
@@ -93,4 +33,84 @@ export interface AllocationItem {
 
 export function encodeAllocation(allocation: Allocation): Bytes32 {
   return defaultAbiCoder.encode(['tuple(bytes32 destination, uint256 amount)[]'], [allocation]);
+}
+export function isAllocation(
+  allocationOrGuarantee: Allocation | Guarantee,
+): allocationOrGuarantee is Allocation {
+  return Array.isArray(allocationOrGuarantee);
+}
+
+// Guarantee Outcome and functions
+export interface GuaranteeOutcome {
+  assetHolderAddress: Address;
+  guarantee: Guarantee;
+}
+export function isGuaranteeOutcome(assetOutcome: AssetOutcome): assetOutcome is GuaranteeOutcome {
+  return 'guarantee' in assetOutcome;
+}
+
+// Allocation outcome and functions
+export interface AllocationOutcome {
+  assetHolderAddress: Address;
+  allocation: AllocationItem[];
+}
+export function isAllocationOutcome(assetOutcome: AssetOutcome): assetOutcome is AllocationOutcome {
+  return 'allocation' in assetOutcome;
+}
+
+// Labelled outcome functions
+export function encodeLabelledOutcome(outcomeType: OutcomeType, encodedData: Bytes32): Bytes32 {
+  return defaultAbiCoder.encode(
+    ['tuple(uint8 outcomeType, bytes allocationOrGuarantee)'],
+    [{outcomeType, allocationOrGuarantee: encodedData}],
+  );
+}
+// Outcome content functions
+export function hashOutcomeContent(allocationOrGuarantee: Allocation | Guarantee): Bytes32 {
+  return keccak256(encodeOutcomeContent(allocationOrGuarantee));
+}
+export function encodeOutcomeContent(allocationOrGuarantee: Allocation | Guarantee): Bytes32 {
+  let encodedData;
+  let outcomeType;
+  if (isAllocation(allocationOrGuarantee)) {
+    encodedData = encodeAllocation(allocationOrGuarantee);
+    outcomeType = OutcomeType.AllocationOutcomeType;
+  } else {
+    encodedData = encodeGuarantee(allocationOrGuarantee);
+    outcomeType = OutcomeType.GuaranteeOutcomeType;
+  }
+  return encodeLabelledOutcome(outcomeType, encodedData);
+}
+
+// Outcome and functions
+export type AssetOutcome = AllocationOutcome | GuaranteeOutcome;
+export type Outcome = AssetOutcome[];
+
+export function hashOutcome(outcome: Outcome): Bytes32 {
+  const encodedOutcome = encodeOutcome(outcome);
+  return keccak256(defaultAbiCoder.encode(['bytes'], [encodedOutcome]));
+}
+
+export function encodeOutcome(outcome: Outcome): Bytes32 {
+  const encodedAssetOutcomes = outcome.map(o => {
+    let encodedData;
+    let outcomeType;
+    if (isAllocationOutcome(o)) {
+      encodedData = encodeAllocation(o.allocation);
+      outcomeType = OutcomeType.AllocationOutcomeType;
+    } else {
+      encodedData = encodeGuarantee(o.guarantee);
+      outcomeType = OutcomeType.GuaranteeOutcomeType;
+    }
+
+    return {
+      assetHolderAddress: o.assetHolderAddress,
+      outcomeContent: encodeLabelledOutcome(outcomeType, encodedData),
+    };
+  });
+
+  return defaultAbiCoder.encode(
+    ['tuple(address assetHolderAddress, bytes outcomeContent)[]'],
+    [encodedAssetOutcomes],
+  );
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,0 +1,59 @@
+import {Channel, getChannelId} from './channel';
+import {Outcome, encodeOutcome, hashOutcome} from './outcome';
+import {Uint256, Address, Bytes, Bytes32} from './types';
+import abi from 'web3-eth-abi';
+import {keccak256, defaultAbiCoder} from 'ethers/utils';
+
+export interface State {
+  turnNum: number;
+  isFinal: boolean;
+  channel: Channel;
+  challengeDuration: string;
+  outcome: Outcome;
+  appDefinition: string;
+  appData: string;
+}
+
+export function getFixedPart(
+  state: State,
+): {
+  chainId: Uint256;
+  participants: Address[];
+  channelNonce: Uint256;
+  appDefinition: Address;
+  challengeDuration: Uint256;
+} {
+  const {appDefinition, challengeDuration, channel} = state;
+  const {chainId, participants, channelNonce} = channel;
+  return {chainId, participants, channelNonce, appDefinition, challengeDuration};
+}
+
+export function getVariablePart(state: State): {outcome: Bytes32; appData: Bytes32} {
+  return {outcome: encodeOutcome(state.outcome), appData: state.appData};
+}
+
+export function hashAppPart(state: State): Bytes32 {
+  const {challengeDuration, appDefinition, appData} = state;
+  return keccak256(
+    defaultAbiCoder.encode(
+      ['uint256', 'address', 'bytes'],
+      [challengeDuration, appDefinition, appData],
+    ),
+  );
+}
+
+export function hashState(state: State): Bytes32 {
+  const {turnNum, isFinal} = state;
+  const channelId = getChannelId(state.channel);
+  const appPartHash = hashAppPart(state);
+  const outcomeHash = hashOutcome(state.outcome);
+
+  return keccak256(
+    defaultAbiCoder.encode(
+      [
+        'tuple(uint256 turnNum, bool isFinal, bytes32 channelId, bytes32 appPartHash, bytes32 outcomeHash)',
+      ],
+      [{turnNum, isFinal, channelId, appPartHash, outcomeHash}],
+    ),
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 export type Address = string;
 
-export type Byte = string; // should be 4 long: 0x + val
-export type Bytes32 = string; // should be 64 long: 0x + val
+export type Byte = string; // 0x + val(length 4)
+export type Bytes32 = string; // 0x + val(length 64)
 export type Bytes = string;
 
 // ethersjs lets you pass, and returns a number, for solidity variables of

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,14 @@
+export type Address = string;
+
+export type Byte = string; // should be 4 long: 0x + val
+export type Bytes32 = string; // should be 64 long: 0x + val
+export type Bytes = string;
+
+// ethersjs lets you pass, and returns a number, for solidity variables of
+// the types uint8, uint16, and uint32
+export type Uint8 = number;
+export type Uint32 = number;
+// these can only be safely stored as a hex string, which is the type that ethers returns
+export type Uint64 = string;
+export type Uint128 = string;
+export type Uint256 = string;

--- a/test/AssetHolder/claimAll.test.ts
+++ b/test/AssetHolder/claimAll.test.ts
@@ -11,7 +11,7 @@ import {
 } from '../test-helpers';
 import {HashZero, AddressZero} from 'ethers/constants';
 import {BigNumber} from 'ethers/utils';
-import {Guarantee, GuaranteeOutcome, AllocationOutcome, Allocation} from '../../src/outcome.js';
+import {Allocation} from '../../src/outcome.js';
 
 const provider = new ethers.providers.JsonRpcProvider(
   `http://localhost:${process.env.DEV_GANACHE_PORT}`,
@@ -83,12 +83,8 @@ describe('claimAll', () => {
         destination: x,
         amount: cAmountsBefore[index],
       }));
-      const allocationOutcome: AllocationOutcome = {
-        allocation,
-        assetHolderAddress: AddressZero,
-      };
 
-      const [allocationBytes, outcomeHash] = allocationToParams(allocationOutcome);
+      const [allocationBytes, outcomeHash] = allocationToParams(allocation);
 
       // set outcomeHash
       if (outcomeSet[0]) {
@@ -100,11 +96,8 @@ describe('claimAll', () => {
         destinations: guaranteeDestinations,
         guaranteedChannelAddress: targetId,
       };
-      const guaranteeOutcome: GuaranteeOutcome = {
-        assetHolderAddress: AddressZero,
-        guarantee,
-      };
-      const [guaranteeBytes, gOutcomeContentHash] = guaranteeToParams(guaranteeOutcome);
+
+      const [guaranteeBytes, gOutcomeContentHash] = guaranteeToParams(guarantee);
 
       if (outcomeSet[1]) {
         await (await AssetHolder.setOutcomePermissionless(guarantorId, gOutcomeContentHash)).wait();
@@ -155,12 +148,7 @@ describe('claimAll', () => {
             amount: cAmountsAfter[index],
           }));
 
-          const allocationOutcomeAfter: AllocationOutcome = {
-            assetHolderAddress: AddressZero,
-            allocation: allocationAfter,
-          };
-
-          [_, expectedNewOutcomeHash] = allocationToParams(allocationOutcomeAfter);
+          [_, expectedNewOutcomeHash] = allocationToParams(allocationAfter);
         } else {
           expectedNewOutcomeHash = HashZero;
         }

--- a/test/AssetHolder/claimAll.test.ts
+++ b/test/AssetHolder/claimAll.test.ts
@@ -38,16 +38,16 @@ const description3 =
 const description4 = 'Reverts when allocation not on chain';
 const description5 = 'Reverts when guarantee not on chain';
 
-// amounts are valueString represenationa of wei
+// amounts are valueString representations of wei
 describe('claimAll', () => {
   it.each`
-    description     | cNonce | cDestBefore  | cAmountsBefore     | cDestAfter | cAmountsAfter | gNonce | guarantee    | gHeldBefore | gHeldAfter | outcomeSet       | payouts            | reasonString
-    ${description0} | ${0}   | ${[I, A, B]} | ${['5', '5', '5']} | ${[A, B]}  | ${['5', '5']} | ${100} | ${[I, A, B]} | ${'5'}      | ${'0'}     | ${[true, true]}  | ${['5', '0', '0']} | ${undefined}
-    ${description1} | ${1}   | ${[A, B]}    | ${['5', '5']}      | ${[A]}     | ${['5']}      | ${101} | ${[I, B, A]} | ${'5'}      | ${'0'}     | ${[true, true]}  | ${['0', '5']}      | ${undefined}
-    ${description2} | ${0}   | ${[I, A, B]} | ${['5', '5', '5']} | ${[A, B]}  | ${['5', '5']} | ${100} | ${[I, B, A]} | ${'5'}      | ${'0'}     | ${[true, true]}  | ${['5', '0', '0']} | ${undefined}
-    ${description3} | ${3}   | ${[A, B]}    | ${['5', '5']}      | ${[B]}     | ${['5']}      | ${103} | ${[I, A, B]} | ${'5'}      | ${'0'}     | ${[true, true]}  | ${['5', '0']}      | ${undefined}
-    ${description4} | ${3}   | ${[A, B]}    | ${['5', '5']}      | ${[B]}     | ${['5']}      | ${103} | ${[I, A, B]} | ${'5'}      | ${'0'}     | ${[false, true]} | ${['5', '0']}      | ${'claimAll | submitted data does not match outcomeHash stored against guaranteedChannelId'}
-    ${description5} | ${3}   | ${[A, B]}    | ${['5', '5']}      | ${[B]}     | ${['5']}      | ${103} | ${[I, A, B]} | ${'5'}      | ${'0'}     | ${[true, false]} | ${['5', '0']}      | ${'claimAll | submitted data does not match outcomeHash stored against channelId'}
+    description     | cNonce | cDestBefore  | cAmountsBefore     | cDestAfter | cAmountsAfter | gNonce | guaranteeDestinations | gHeldBefore | gHeldAfter | outcomeSet       | payouts            | reasonString
+    ${description0} | ${0}   | ${[I, A, B]} | ${['5', '5', '5']} | ${[A, B]}  | ${['5', '5']} | ${100} | ${[I, A, B]}          | ${'5'}      | ${'0'}     | ${[true, true]}  | ${['5', '0', '0']} | ${undefined}
+    ${description1} | ${1}   | ${[A, B]}    | ${['5', '5']}      | ${[A]}     | ${['5']}      | ${101} | ${[I, B, A]}          | ${'5'}      | ${'0'}     | ${[true, true]}  | ${['0', '5']}      | ${undefined}
+    ${description2} | ${0}   | ${[I, A, B]} | ${['5', '5', '5']} | ${[A, B]}  | ${['5', '5']} | ${100} | ${[I, B, A]}          | ${'5'}      | ${'0'}     | ${[true, true]}  | ${['5', '0', '0']} | ${undefined}
+    ${description3} | ${3}   | ${[A, B]}    | ${['5', '5']}      | ${[B]}     | ${['5']}      | ${103} | ${[I, A, B]}          | ${'5'}      | ${'0'}     | ${[true, true]}  | ${['5', '0']}      | ${undefined}
+    ${description4} | ${3}   | ${[A, B]}    | ${['5', '5']}      | ${[B]}     | ${['5']}      | ${103} | ${[I, A, B]}          | ${'5'}      | ${'0'}     | ${[false, true]} | ${['5', '0']}      | ${'claimAll | submitted data does not match outcomeHash stored against guaranteedChannelId'}
+    ${description5} | ${3}   | ${[A, B]}    | ${['5', '5']}      | ${[B]}     | ${['5']}      | ${103} | ${[I, A, B]}          | ${'5'}      | ${'0'}     | ${[true, false]} | ${['5', '0']}      | ${'claimAll | submitted data does not match outcomeHash stored against channelId'}
   `(
     '$description',
     async ({
@@ -57,7 +57,7 @@ describe('claimAll', () => {
       cDestAfter,
       cAmountsAfter,
       gNonce,
-      guarantee: guaranteeDestinations,
+      guaranteeDestinations,
       gHeldBefore,
       gHeldAfter,
       outcomeSet,

--- a/test/AssetHolder/setOutcome.test.ts
+++ b/test/AssetHolder/setOutcome.test.ts
@@ -2,8 +2,9 @@ import {ethers} from 'ethers';
 // @ts-ignore
 import AssetHolderArtifact from '../../build/contracts/ETHAssetHolder.json';
 import {setupContracts} from '../test-helpers';
-import {keccak256, defaultAbiCoder} from 'ethers/utils';
+import {keccak256} from 'ethers/utils';
 import {expectRevert} from 'magmo-devtools';
+import {Channel, getChannelId} from '../../src/channel';
 
 const provider = new ethers.providers.JsonRpcProvider(
   `http://localhost:${process.env.DEV_GANACHE_PORT}`,
@@ -13,8 +14,8 @@ let channelId;
 
 const participants = ['', '', ''];
 const wallets = new Array(3);
-const chainId = 1234;
-const channelNonce = 9999;
+const chainId = '0x1234';
+const channelNonce = '0x9999';
 const outcomeContent = ethers.utils.id('some outcome data');
 
 // populate wallets and participants array
@@ -25,12 +26,8 @@ for (let i = 0; i < 3; i++) {
 
 beforeAll(async () => {
   AssetHolder = await setupContracts(provider, AssetHolderArtifact);
-  channelId = keccak256(
-    defaultAbiCoder.encode(
-      ['uint256', 'address[]', 'uint256'],
-      [chainId, participants, channelNonce],
-    ),
-  );
+  const channel: Channel = {chainId, participants, channelNonce};
+  channelId = getChannelId(channel);
 });
 
 describe('setOutcome', () => {

--- a/test/AssetHolder/transferAll.test.ts
+++ b/test/AssetHolder/transferAll.test.ts
@@ -2,13 +2,9 @@ import {ethers} from 'ethers';
 import {expectRevert} from 'magmo-devtools';
 // @ts-ignore
 import AssetHolderArtifact from '../../build/contracts/TESTAssetHolder.json';
-import {
-  setupContracts,
-  newAssetTransferredEvent,
-  randomChannelId,
-  allocationToParams,
-} from '../test-helpers';
-import {HashZero} from 'ethers/constants';
+import {setupContracts, newAssetTransferredEvent, randomChannelId} from '../test-helpers';
+import {HashZero, AddressZero} from 'ethers/constants';
+import {encodeAllocation, hashOutcomeContent, AllocationOutcome} from '../../src/outcome';
 
 const provider = new ethers.providers.JsonRpcProvider(
   `http://localhost:${process.env.DEV_GANACHE_PORT}`,
@@ -22,6 +18,13 @@ let assetTransferredEvent;
 let assetTransferredEvent0;
 let assetTransferredEvent1;
 const participants = ['', '', ''];
+
+function allocationToParams(allocationOutcome: AllocationOutcome) {
+  const allocationBytes = encodeAllocation(allocationOutcome.allocation);
+
+  const outcomeContentHash = hashOutcomeContent(allocationOutcome);
+  return [allocationBytes, outcomeContentHash];
+}
 
 beforeAll(async () => {
   AssetHolder = await setupContracts(provider, AssetHolderArtifact);
@@ -92,7 +95,10 @@ describe('transferAll (single beneficiary)', () => {
 
       // compute an appropriate allocation
       const allocation = [{destination, amount: allocated}]; // sufficient
-      const [allocationBytes, outcomeHash] = allocationToParams(allocation);
+      const [allocationBytes, outcomeHash] = allocationToParams({
+        assetHolderAddress: AddressZero,
+        allocation,
+      });
 
       // set outcomeHash
       if (outcomeSet) {
@@ -135,7 +141,10 @@ describe('transferAll (single beneficiary)', () => {
           expectedOutcomeHash = HashZero;
         } else {
           const newAllocation = [{destination, amount: allocated.sub(amount)}]; // sufficient
-          [_, expectedOutcomeHash] = allocationToParams(newAllocation);
+          [_, expectedOutcomeHash] = allocationToParams({
+            assetHolderAddress: AddressZero,
+            allocation: newAllocation,
+          });
         }
 
         expect(await AssetHolder.outcomeHashes(channelId)).toEqual(expectedOutcomeHash);
@@ -195,7 +204,10 @@ describe('transferAll (two beneficiaries)', () => {
         {destination: destination0, amount: allocated[0]},
         {destination: destination1, amount: allocated[1]},
       ];
-      const [allocationBytes, outcomeHash] = allocationToParams(allocation);
+      const [allocationBytes, outcomeHash] = allocationToParams({
+        assetHolderAddress: AddressZero,
+        allocation,
+      });
 
       // set outcomeHash
       if (outcomeSet) {
@@ -264,7 +276,10 @@ describe('transferAll (two beneficiaries)', () => {
           if (allocated[1].sub(amount[1]).gt(0)) {
             newAllocation.push({destination: destination1, amount: allocated[1].sub(amount[1])});
           }
-          [_, expectedOutcomeHash] = allocationToParams(newAllocation);
+          [_, expectedOutcomeHash] = allocationToParams({
+            allocation: newAllocation,
+            assetHolderAddress: AddressZero,
+          });
         }
 
         expect(await AssetHolder.outcomeHashes(channelId)).toEqual(expectedOutcomeHash);

--- a/test/ForceMove/concludeFromChallenge.test.ts
+++ b/test/ForceMove/concludeFromChallenge.test.ts
@@ -4,9 +4,18 @@ import {expectRevert} from 'magmo-devtools';
 import ForceMoveArtifact from '../../build/contracts/TESTForceMove.json';
 // @ts-ignore
 import countingAppArtifact from '../../build/contracts/CountingApp.json';
-import {keccak256, defaultAbiCoder, toUtf8Bytes} from 'ethers/utils';
+import {keccak256, defaultAbiCoder, bigNumberify} from 'ethers/utils';
 import {setupContracts, sign, newConcludedEvent, clearedChallengeHash} from '../test-helpers';
 import {HashZero, AddressZero} from 'ethers/constants';
+import {Channel, getChannelId} from '../../src/channel';
+import {State, hashState, hashAppPart, getFixedPart} from '../../src/state';
+import {Outcome, hashOutcome} from '../../src/outcome';
+import {Bytes32} from '../../src/types.js';
+import {
+  encodeChannelStorageLite,
+  ChannelStorage,
+  hashChannelStorage,
+} from '../../src/channel-storage';
 
 const provider = new ethers.providers.JsonRpcProvider(
   `http://localhost:${process.env.DEV_GANACHE_PORT}`,
@@ -15,12 +24,12 @@ let ForceMove: ethers.Contract;
 let networkId;
 let blockNumber;
 let blockTimestamp;
-const chainId = 1234;
+const chainId = '0x1234';
 const participants = ['', '', ''];
 const wallets = new Array(3);
-const challengeDuration = 1000;
-const outcome = ethers.utils.id('some outcome data'); // use a fixed outcome for all state updates in all tests
-const outcomeHash = keccak256(defaultAbiCoder.encode(['bytes'], [outcome]));
+const challengeDuration = '0x1000';
+const assetHolderAddress = ethers.Wallet.createRandom().address;
+const outcome: Outcome = [{assetHolderAddress, allocation: []}];
 let appDefinition;
 
 // populate wallets and participants array
@@ -67,66 +76,32 @@ describe('concludeFromChallenge', () => {
       reasonString,
     }) => {
       // compute channelId
-      const channelId = keccak256(
-        defaultAbiCoder.encode(
-          ['uint256', 'address[]', 'uint256'],
-          [chainId, participants, channelNonce],
-        ),
-      );
-      // fixedPart
-      const fixedPart = {
-        chainId,
-        participants,
-        channelNonce,
-        appDefinition,
+      const channel: Channel = {chainId, participants, channelNonce};
+      const challengeState: State = {
+        channel,
         challengeDuration,
-      };
-
-      const appPartHash = keccak256(
-        defaultAbiCoder.encode(
-          ['uint256', 'address'], // note lack of appData
-          [challengeDuration, appDefinition],
-        ),
-      );
-
-      const challengeAppData = 0;
-      const challengeAppPartHash = keccak256(
-        defaultAbiCoder.encode(
-          ['uint256', 'address', 'bytes'],
-          [
-            challengeDuration,
-            appDefinition,
-            defaultAbiCoder.encode(['uint256'], [challengeAppData]),
-          ],
-        ),
-      );
-
-      const challengeState = {
         turnNum: setTurnNumRecord,
-        isFinal: false, // TODO consider having this as a test parameter
-        channelId,
-        challengeAppPartHash,
-        outcomeHash,
+        appDefinition,
+        appData: '0x0',
+        isFinal: false,
+        outcome,
       };
 
-      const challengeStateHash = keccak256(
-        defaultAbiCoder.encode(
-          [
-            'tuple(uint256 turnNum, bool isFinal, bytes32 channelId, bytes32 challengeAppPartHash, bytes32 outcomeHash)',
-          ],
-          [challengeState],
-        ),
-      );
+      const channelId = getChannelId(channel);
 
       // set expiry time in the future or in the past
       blockNumber = await provider.getBlockNumber();
       blockTimestamp = (await provider.getBlock(blockNumber)).timestamp;
       const finalizesAt = expired
-        ? blockTimestamp - challengeDuration
-        : blockTimestamp + challengeDuration;
+        ? blockTimestamp - bigNumberify(challengeDuration).toNumber()
+        : blockTimestamp + bigNumberify(challengeDuration).toNumber();
 
       // compute expected ChannelStorageHash
       const challengerAddress = wallets[2].address;
+
+      const challengeStateHash = hashState(challengeState);
+      const outcomeHash = hashOutcome(outcome);
+
       const challengeExistsHash = keccak256(
         defaultAbiCoder.encode(
           ['uint256', 'uint256', 'bytes32', 'address', 'bytes32'],
@@ -145,23 +120,18 @@ describe('concludeFromChallenge', () => {
       );
 
       // compute stateHashes
-      const stateHashes = new Array(numStates);
+      const stateHashes: Bytes32[] = [];
       for (let i = 0; i < numStates; i++) {
-        const state = {
+        const state: State = {
           turnNum: largestTurnNum + i - numStates,
           isFinal: true,
-          channelId,
-          appPartHash,
-          outcomeHash,
+          channel,
+          appDefinition,
+          appData: '0x0',
+          challengeDuration,
+          outcome,
         };
-        stateHashes[i] = keccak256(
-          defaultAbiCoder.encode(
-            [
-              'tuple(uint256 turnNum, bool isFinal, bytes32 channelId, bytes32 appPartHash, bytes32 outcomeHash)',
-            ],
-            [state],
-          ),
-        );
+        stateHashes.push(hashState(state));
       }
 
       // sign the states
@@ -171,13 +141,15 @@ describe('concludeFromChallenge', () => {
         sigs[i] = {v: sig.v, r: sig.r, s: sig.s};
       }
 
-      // pack arguemtns
-      const ChannelStorageLite =
-        'tuple(uint256 finalizesAt, bytes32 stateHash, address challengerAddress, bytes32 outcomeHash)';
-      const channelStorageLiteBytes = defaultAbiCoder.encode(
-        [ChannelStorageLite],
-        [[finalizesAt, challengeStateHash, challengerAddress, outcomeHash]],
-      );
+      const channelStorageLiteBytes = encodeChannelStorageLite({
+        state: challengeState,
+        outcome,
+        finalizesAt,
+        challengerAddress,
+      });
+
+      const fixedPart = getFixedPart(challengeState);
+      const appPartHash = hashAppPart(challengeState);
 
       // call method in a slightly different way if expecting a revert
       if (reasonString) {
@@ -223,13 +195,13 @@ describe('concludeFromChallenge', () => {
         // compute expected ChannelStorageHash
         blockNumber = await provider.getBlockNumber();
         blockTimestamp = (await provider.getBlock(blockNumber)).timestamp;
-        const expectedChannelStorage = [0, blockTimestamp, HashZero, AddressZero, outcomeHash];
-        const expectedChannelStorageHash = keccak256(
-          defaultAbiCoder.encode(
-            ['uint256', 'uint256', 'bytes32', 'address', 'bytes32'],
-            expectedChannelStorage,
-          ),
-        );
+        const expectedChannelStorage: ChannelStorage = {
+          largestTurnNum: '0x0',
+          finalizesAt: blockTimestamp,
+          challengerAddress: AddressZero,
+          outcome,
+        };
+        const expectedChannelStorageHash = hashChannelStorage(expectedChannelStorage);
 
         // check channelStorageHash against the expected value
 

--- a/test/ForceMove/refute.test.ts
+++ b/test/ForceMove/refute.test.ts
@@ -4,21 +4,25 @@ import {expectRevert} from 'magmo-devtools';
 import ForceMoveArtifact from '../../build/contracts/TESTForceMove.json';
 // @ts-ignore
 import countingAppArtifact from '../../build/contracts/CountingApp.json';
-import {keccak256, defaultAbiCoder, hexlify, toUtf8Bytes} from 'ethers/utils';
+import {keccak256, defaultAbiCoder, hexlify, toUtf8Bytes, bigNumberify} from 'ethers/utils';
 import {setupContracts, sign, newChallengeClearedEvent} from '../test-helpers';
 import {HashZero, AddressZero} from 'ethers/constants';
+import {Channel, getChannelId} from '../../src/channel';
+import {State, hashState, getFixedPart, getVariablePart} from '../../src/state';
+import {Outcome, hashOutcome} from '../../src/outcome';
+import {hashChannelStorage, ChannelStorage} from '../../src/channel-storage';
 
 const provider = new ethers.providers.JsonRpcProvider(
   `http://localhost:${process.env.DEV_GANACHE_PORT}`,
 );
 let ForceMove: ethers.Contract;
 let networkId;
-const chainId = 1234;
+const chainId = '0x1234';
 const participants = ['', '', ''];
 const wallets = new Array(3);
-const challengeDuration = 1000;
-const outcome = ethers.utils.id('some outcome data'); // use a fixed outcome for all state updates in all tests
-const outcomeHash = keccak256(defaultAbiCoder.encode(['bytes'], [outcome]));
+const challengeDuration = '0x1000';
+const assetHolderAddress = ethers.Wallet.createRandom().address;
+const outcome: Outcome = [{assetHolderAddress, allocation: []}];
 let appDefinition;
 
 // populate wallets and participants array
@@ -66,93 +70,52 @@ describe('refute', () => {
       refutationStateSigner,
       reasonString,
     }) => {
-      // compute channelId
-      const channelId = keccak256(
-        defaultAbiCoder.encode(
-          ['uint256', 'address[]', 'uint256'],
-          [chainId, participants, channelNonce],
-        ),
-      );
-      // fixedPart
-      const fixedPart = {
-        chainId,
-        participants,
-        channelNonce,
+      const channel: Channel = {chainId, channelNonce, participants};
+      const channelId = getChannelId(channel);
+      const challengeState: State = {
+        turnNum: setTurnNumRecord,
+        isFinal: isFinalAB[0],
+        appData: defaultAbiCoder.encode(['uint256'], [appDatas[0]]),
+        outcome,
+        challengeDuration,
+        channel,
+        appDefinition,
+      };
+
+      const refutationState: State = {
+        turnNum: refutationTurnNum,
+        isFinal: isFinalAB[1],
+        channel,
+        appData: defaultAbiCoder.encode(['uint256'], [appDatas[0]]),
+        outcome,
         appDefinition,
         challengeDuration,
       };
 
-      const challengeAppPartHash = keccak256(
-        defaultAbiCoder.encode(
-          ['uint256', 'address', 'bytes'],
-          [challengeDuration, appDefinition, defaultAbiCoder.encode(['uint256'], [appDatas[0]])],
-        ),
-      );
-
-      const challengeState = {
-        turnNum: setTurnNumRecord,
-        isFinal: isFinalAB[0],
-        channelId,
-        challengeAppPartHash,
-        outcomeHash,
-      };
-
-      const challengeStateHash = keccak256(
-        defaultAbiCoder.encode(
-          [
-            'tuple(uint256 turnNum, bool isFinal, bytes32 channelId, bytes32 challengeAppPartHash, bytes32 outcomeHash)',
-          ],
-          [challengeState],
-        ),
-      );
-
-      const refutationAppPartHash = keccak256(
-        defaultAbiCoder.encode(
-          ['uint256', 'address', 'bytes'],
-          [challengeDuration, appDefinition, defaultAbiCoder.encode(['uint256'], [appDatas[1]])],
-        ),
-      );
-
-      const refutationState = {
-        turnNum: refutationTurnNum,
-        isFinal: isFinalAB[1],
-        channelId,
-        refutationAppPartHash,
-        outcomeHash,
-      };
-
-      const refutationStateHash = keccak256(
-        defaultAbiCoder.encode(
-          [
-            'tuple(uint256 turnNum, bool isFinal, bytes32 channelId, bytes32 refutationAppPartHash, bytes32 outcomeHash)',
-          ],
-          [refutationState],
-        ),
-      );
-
-      const challengeVariablePart = {
-        outcome,
-        appData: defaultAbiCoder.encode(['uint256'], [appDatas[0]]), // a counter
-      };
-      const refutationVariablePart = {
-        outcome,
-        appData: defaultAbiCoder.encode(['uint256'], [appDatas[1]]), // a counter
-      };
+      const fixedPart = getFixedPart(challengeState);
+      const challengeVariablePart = getVariablePart(challengeState);
+      const refutationVariablePart = getVariablePart(refutationState);
 
       // set expiry time in the future or in the past
       const blockNumber = await provider.getBlockNumber();
       const blockTimestamp = (await provider.getBlock(blockNumber)).timestamp;
       const finalizesAt = expired
-        ? blockTimestamp - challengeDuration
-        : blockTimestamp + challengeDuration;
+        ? bigNumberify(blockTimestamp)
+            .sub(challengeDuration)
+            .toHexString()
+        : bigNumberify(blockTimestamp)
+            .add(challengeDuration)
+            .toHexString();
 
       // compute expected ChannelStorageHash
-      const challengeExistsHash = keccak256(
-        defaultAbiCoder.encode(
-          ['uint256', 'uint256', 'bytes32', 'address', 'bytes32'],
-          [setTurnNumRecord, finalizesAt, challengeStateHash, challenger.address, outcomeHash],
-        ),
-      );
+
+      const challengeExistsHash = hashChannelStorage({
+        largestTurnNum: setTurnNumRecord,
+        finalizesAt,
+        state: challengeState,
+        challengerAddress: challenger.address,
+        outcome,
+      });
 
       // call public wrapper to set state (only works on test contract)
       const tx = await ForceMove.setChannelStorageHash(channelId, challengeExistsHash);
@@ -160,7 +123,7 @@ describe('refute', () => {
       expect(await ForceMove.channelStorageHashes(channelId)).toEqual(challengeExistsHash);
 
       // sign the state
-      const signature = await sign(refutationStateSigner, refutationStateHash);
+      const signature = await sign(refutationStateSigner, hashState(refutationState));
       const refutationStateSig = {v: signature.v, r: signature.r, s: signature.s};
 
       if (reasonString) {
@@ -199,14 +162,13 @@ describe('refute', () => {
         const [_, eventTurnNumRecord] = await challengeClearedEvent;
         expect(eventTurnNumRecord._hex).toEqual(hexlify(declaredTurnNumRecord));
 
-        // compute and check new expected ChannelStorageHash
-        const expectedChannelStorage = [declaredTurnNumRecord, 0, HashZero, AddressZero, HashZero];
-        const expectedChannelStorageHash = keccak256(
-          defaultAbiCoder.encode(
-            ['uint256', 'uint256', 'bytes32', 'address', 'bytes32'],
-            expectedChannelStorage,
-          ),
-        );
+        // check new expected ChannelStorageHash
+        const expectedChannelStorage: ChannelStorage = {
+          largestTurnNum: declaredTurnNumRecord,
+          finalizesAt: '0x0',
+          challengerAddress: AddressZero,
+        };
+        const expectedChannelStorageHash = hashChannelStorage(expectedChannelStorage);
         expect(await ForceMove.channelStorageHashes(channelId)).toEqual(expectedChannelStorageHash);
       }
     },

--- a/test/ForceMove/respond.test.ts
+++ b/test/ForceMove/respond.test.ts
@@ -4,21 +4,25 @@ import {expectRevert} from 'magmo-devtools';
 import ForceMoveArtifact from '../../build/contracts/TESTForceMove.json';
 // @ts-ignore
 import countingAppArtifact from '../../build/contracts/CountingApp.json';
-import {keccak256, defaultAbiCoder, hexlify, toUtf8Bytes} from 'ethers/utils';
+import {keccak256, defaultAbiCoder, hexlify, toUtf8Bytes, bigNumberify} from 'ethers/utils';
 import {setupContracts, sign, newChallengeClearedEvent} from '../test-helpers';
 import {HashZero, AddressZero} from 'ethers/constants';
+import {Outcome, hashOutcome} from '../../src/outcome';
+import {Channel, getChannelId} from '../../src/channel';
+import {State, hashState, getVariablePart, getFixedPart} from '../../src/state';
+import {hashChannelStorage} from '../../src/channel-storage';
 
 const provider = new ethers.providers.JsonRpcProvider(
   `http://localhost:${process.env.DEV_GANACHE_PORT}`,
 );
 let ForceMove: ethers.Contract;
 let networkId;
-const chainId = 1234;
+const chainId = '0x1234';
 const participants = ['', '', ''];
 const wallets = new Array(3);
-const challengeDuration = 1000;
-const outcome = ethers.utils.id('some outcome data'); // use a fixed outcome for all state updates in all tests
-const outcomeHash = keccak256(defaultAbiCoder.encode(['bytes'], [outcome]));
+const challengeDuration = '0x1000';
+const assetHolderAddress = ethers.Wallet.createRandom().address;
+const outcome: Outcome = [{assetHolderAddress, allocation: []}];
 let appDefinition;
 
 // populate wallets and participants array
@@ -64,93 +68,56 @@ describe('respond', () => {
       responder,
       reasonString,
     }) => {
-      // compute channelId
-      const channelId = keccak256(
-        defaultAbiCoder.encode(
-          ['uint256', 'address[]', 'uint256'],
-          [chainId, participants, channelNonce],
-        ),
-      );
-      // fixedPart
-      const fixedPart = {
-        chainId,
-        participants,
-        channelNonce,
+      const channel: Channel = {chainId, channelNonce, participants};
+      const channelId = getChannelId(channel);
+
+      const challengeState: State = {
+        turnNum: setTurnNumRecord,
+        isFinal: isFinalAB[0],
+        channel,
+        outcome,
+        appData: defaultAbiCoder.encode(['uint256'], [appDatas[0]]),
         appDefinition,
         challengeDuration,
       };
 
-      const challengeAppPartHash = keccak256(
-        defaultAbiCoder.encode(
-          ['uint256', 'address', 'bytes'],
-          [challengeDuration, appDefinition, defaultAbiCoder.encode(['uint256'], [appDatas[0]])],
-        ),
-      );
-
-      const challengeState = {
-        turnNum: setTurnNumRecord,
-        isFinal: isFinalAB[0],
-        channelId,
-        challengeAppPartHash,
-        outcomeHash,
-      };
-
-      const challengeStateHash = keccak256(
-        defaultAbiCoder.encode(
-          [
-            'tuple(uint256 turnNum, bool isFinal, bytes32 channelId, bytes32 challengeAppPartHash, bytes32 outcomeHash)',
-          ],
-          [challengeState],
-        ),
-      );
-
-      const responseAppPartHash = keccak256(
-        defaultAbiCoder.encode(
-          ['uint256', 'address', 'bytes'],
-          [challengeDuration, appDefinition, defaultAbiCoder.encode(['uint256'], [appDatas[1]])],
-        ),
-      );
-
-      const responseState = {
+      const responseState: State = {
         turnNum: setTurnNumRecord + 1,
         isFinal: isFinalAB[1],
-        channelId,
-        responseAppPartHash,
-        outcomeHash,
+        channel,
+        outcome,
+        appData: defaultAbiCoder.encode(['uint256'], [appDatas[1]]),
+        appDefinition,
+        challengeDuration,
       };
 
-      const responseStateHash = keccak256(
-        defaultAbiCoder.encode(
-          [
-            'tuple(uint256 turnNum, bool isFinal, bytes32 channelId, bytes32 responseAppPartHash, bytes32 outcomeHash)',
-          ],
-          [responseState],
-        ),
-      );
+      const responseStateHash = hashState(responseState);
 
-      const challengeVariablePart = {
-        outcome,
-        appData: defaultAbiCoder.encode(['uint256'], [appDatas[0]]), // a counter
-      };
-      const responseVariablePart = {
-        outcome,
-        appData: defaultAbiCoder.encode(['uint256'], [appDatas[1]]), // a counter
-      };
+      const challengeVariablePart = getVariablePart(challengeState);
+      const responseVariablePart = getVariablePart(responseState);
 
       // set expiry time in the future or in the past
       const blockNumber = await provider.getBlockNumber();
       const blockTimestamp = (await provider.getBlock(blockNumber)).timestamp;
       const finalizesAt = expired
-        ? blockTimestamp - challengeDuration
-        : blockTimestamp + challengeDuration;
+        ? bigNumberify(blockTimestamp)
+            .sub(challengeDuration)
+            .toHexString()
+        : bigNumberify(blockTimestamp)
+            .add(challengeDuration)
+            .toHexString();
 
-      // compute expected ChannelStorageHash
-      const challengeExistsHash = keccak256(
-        defaultAbiCoder.encode(
-          ['uint256', 'uint256', 'bytes32', 'address', 'bytes32'],
-          [setTurnNumRecord, finalizesAt, challengeStateHash, challenger.address, outcomeHash],
-        ),
-      );
+      const outcomeHash = hashOutcome(outcome);
+
+      const challengeExistsHash = hashChannelStorage({
+        largestTurnNum: setTurnNumRecord,
+        finalizesAt,
+        state: challengeState,
+        challengerAddress: challenger.address,
+        outcome,
+      });
+
+      const fixedPart = getFixedPart(responseState);
 
       // call public wrapper to set state (only works on test contract)
       const tx = await ForceMove.setChannelStorageHash(channelId, challengeExistsHash);
@@ -199,19 +166,12 @@ describe('respond', () => {
         expect(eventTurnNumRecord._hex).toEqual(hexlify(declaredTurnNumRecord + 1));
 
         // compute and check new expected ChannelStorageHash
-        const expectedChannelStorage = [
-          declaredTurnNumRecord + 1,
-          0,
-          HashZero,
-          AddressZero,
-          HashZero,
-        ];
-        const expectedChannelStorageHash = keccak256(
-          defaultAbiCoder.encode(
-            ['uint256', 'uint256', 'bytes32', 'address', 'bytes32'],
-            expectedChannelStorage,
-          ),
-        );
+
+        const expectedChannelStorageHash = hashChannelStorage({
+          largestTurnNum: declaredTurnNumRecord + 1,
+          finalizesAt: '0x0',
+          challengerAddress: AddressZero,
+        });
         expect(await ForceMove.channelStorageHashes(channelId)).toEqual(expectedChannelStorageHash);
       }
     },

--- a/test/NitroAdjudicator/pushOutcome.test.ts
+++ b/test/NitroAdjudicator/pushOutcome.test.ts
@@ -145,10 +145,10 @@ describe('pushOutcome', () => {
         await tx2.wait();
         // check 2x AssetHolder storage against the expected value
         expect(await ETHAssetHolder.outcomeHashes(channelId)).toEqual(
-          hashOutcomeContent(outcome[0]),
+          hashOutcomeContent(outcome[0].allocation),
         );
         expect(await ERC20AssetHolder.outcomeHashes(channelId)).toEqual(
-          hashOutcomeContent(outcome[1]),
+          hashOutcomeContent(outcome[1].allocation),
         );
       }
     },

--- a/test/NitroAdjudicator/pushOutcome.test.ts
+++ b/test/NitroAdjudicator/pushOutcome.test.ts
@@ -6,10 +6,18 @@ import ETHAssetHolderArtifact from '../../build/contracts/ETHAssetHolder.json';
 // @ts-ignore
 import ERC20AssetHolderArtifact from '../../build/contracts/ERC20AssetHolder.json';
 
-import {keccak256, defaultAbiCoder, toUtf8Bytes} from 'ethers/utils';
 import {AddressZero} from 'ethers/constants';
 import {setupContracts, finalizedOutcomeHash} from '../test-helpers';
 import {expectRevert} from 'magmo-devtools';
+import {Channel, getChannelId} from '../../src/channel';
+import {
+  Outcome,
+  hashOutcome,
+  AllocationOutcome,
+  encodeOutcome,
+  hashOutcomeContent,
+} from '../../src/outcome';
+import {State, hashState} from '../../src/state';
 
 const provider = new ethers.providers.JsonRpcProvider(
   `http://localhost:${process.env.DEV_GANACHE_PORT}`,
@@ -20,13 +28,9 @@ let ERC20AssetHolder: ethers.Contract;
 
 // constants for this test suite
 const challengerAddress = AddressZero;
-const chainId = 1234;
+const chainId = '0x1234';
 const participants = ['', '', ''];
 const wallets = new Array(3);
-const outcomeContent = ethers.utils.id('some outcome data'); // just some bytes for now. To actually mean anything, must be properly encoded data
-let outcome;
-let outcomeHash;
-const stateHash = keccak256(defaultAbiCoder.encode(['bytes'], [toUtf8Bytes('mocked state data')]));
 
 // populate wallets and participants array
 for (let i = 0; i < 3; i++) {
@@ -66,33 +70,32 @@ describe('pushOutcome', () => {
       outcomeHashExits,
       reasonString,
     }) => {
-      // compute channelId
-      const channelId = keccak256(
-        defaultAbiCoder.encode(
-          ['uint256', 'address[]', 'uint256'],
-          [chainId, participants, channelNonce],
-        ),
-      );
-
+      const channel: Channel = {chainId, channelNonce, participants};
+      const channelId = getChannelId(channel);
       const finalizesAt = finalized ? 1 : 1e12; // either 1 second after genesis block, or ~ 31000 years after
 
-      const assetOutcomeBytes1 = defaultAbiCoder.encode(
-        ['tuple(address, bytes)'],
-        [[ETHAssetHolder.address, outcomeContent]],
-      );
-      const assetOutcomeBytes2 = defaultAbiCoder.encode(
-        ['tuple(address, bytes)'],
-        [[ERC20AssetHolder.address, outcomeContent]],
-      );
-      outcome = defaultAbiCoder.encode(['bytes[]'], [[assetOutcomeBytes1, assetOutcomeBytes2]]); // use a fixed outcome for all state updates in all tests
-      outcomeHash = keccak256(outcome);
+      const outcome = [
+        {assetHolderAddress: ETHAssetHolder.address, allocation: []},
+        {assetHolderAddress: ERC20AssetHolder.address, allocation: []},
+      ];
+
+      // We don't care about the actual values in the state
+      const state: State = {
+        turnNum: 0,
+        isFinal: false,
+        channel,
+        outcome,
+        appDefinition: AddressZero,
+        appData: '0x0',
+        challengeDuration: '0x1',
+      };
 
       const initialChannelStorageHash = finalizedOutcomeHash(
         storedTurnNumRecord,
         finalizesAt,
-        stateHash,
         challengerAddress,
-        outcomeHash,
+        state,
+        outcome,
       );
       // call public wrapper to set state (only works on test contract)
       const tx = await NitroAdjudicator.setChannelStorageHash(channelId, initialChannelStorageHash);
@@ -106,9 +109,9 @@ describe('pushOutcome', () => {
           channelId,
           declaredTurnNumRecord,
           finalizesAt,
-          stateHash,
+          hashState(state),
           challengerAddress,
-          outcome,
+          encodeOutcome(outcome),
         )).wait();
       }
 
@@ -123,9 +126,9 @@ describe('pushOutcome', () => {
               channelId,
               declaredTurnNumRecord,
               finalizesAt,
-              stateHash,
+              hashState(state),
               challengerAddress,
-              outcome,
+              encodeOutcome(outcome),
             ),
           regex,
         );
@@ -134,15 +137,19 @@ describe('pushOutcome', () => {
           channelId,
           declaredTurnNumRecord,
           finalizesAt,
-          stateHash,
+          hashState(state),
           challengerAddress,
-          outcome,
+          encodeOutcome(outcome),
         );
         // wait for tx to be mined
         await tx2.wait();
         // check 2x AssetHolder storage against the expected value
-        expect(await ETHAssetHolder.outcomeHashes(channelId)).toEqual(keccak256(outcomeContent));
-        expect(await ERC20AssetHolder.outcomeHashes(channelId)).toEqual(keccak256(outcomeContent));
+        expect(await ETHAssetHolder.outcomeHashes(channelId)).toEqual(
+          hashOutcomeContent(outcome[0]),
+        );
+        expect(await ERC20AssetHolder.outcomeHashes(channelId)).toEqual(
+          hashOutcomeContent(outcome[1]),
+        );
       }
     },
   );

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -5,11 +5,11 @@ import {HashZero, AddressZero} from 'ethers/constants';
 import {hashChannelStorage} from '../src/channel-storage';
 import {
   Outcome,
-  AllocationOutcome,
   encodeAllocation,
   hashOutcomeContent,
-  GuaranteeOutcome,
   encodeGuarantee,
+  Guarantee,
+  Allocation,
 } from '../src/outcome';
 import {State} from '../src/state';
 
@@ -159,16 +159,16 @@ export function randomChannelId(channelNonce = 0) {
   return channelId;
 }
 
-export function allocationToParams(allocationOutcome: AllocationOutcome) {
-  const allocationBytes = encodeAllocation(allocationOutcome.allocation);
+export function allocationToParams(allocation: Allocation) {
+  const allocationBytes = encodeAllocation(allocation);
 
-  const outcomeContentHash = hashOutcomeContent(allocationOutcome);
+  const outcomeContentHash = hashOutcomeContent(allocation);
   return [allocationBytes, outcomeContentHash];
 }
 
-export function guaranteeToParams(guaranteeOutcome: GuaranteeOutcome) {
-  const guaranteeBytes = encodeGuarantee(guaranteeOutcome.guarantee);
+export function guaranteeToParams(guarantee: Guarantee) {
+  const guaranteeBytes = encodeGuarantee(guarantee);
 
-  const outcomeContentHash = hashOutcomeContent(guaranteeOutcome);
+  const outcomeContentHash = hashOutcomeContent(guarantee);
   return [guaranteeBytes, outcomeContentHash];
 }


### PR DESCRIPTION
Adds interfaces and functions to encode/hash for
- State
- Outcome
- Channel 
- Channel-Storage

All existing tests have been updated to use these new functions/interfaces instead of manually encoding/hashing data.
