### PR TITLE
Don't debug node internals

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,8 @@
       "internalConsoleOptions": "neverOpen",
       "env": {
         "NODE_ENV": "test"
-      }
+      },
+      "skipFiles": ["${workspaceFolder}/node_modules/**/*.js", "<node_internals>/**/*.js"]
     }
   ]
 }


### PR DESCRIPTION
Add `node_modules` and `nodeInternals` to `skipFiles` to make debugging async functions nicer.