### PR TITLE
Add pushOutcome transaction creator

### DIFF
--- a/src/transaction-creators/force-move.ts
+++ b/src/transaction-creators/force-move.ts
@@ -1,11 +1,11 @@
 // @ts-ignore
-import ForceMoveArtifact from '../build/contracts/ForceMove.json';
+import ForceMoveArtifact from '../../build/contracts/ForceMove.json';
 import * as ethers from 'ethers';
 import {TransactionRequest} from 'ethers/providers';
-import {State, hashState, getVariablePart, getFixedPart, hashAppPart} from './state';
+import {State, hashState, getVariablePart, getFixedPart, hashAppPart} from '../state';
 import {Signature} from 'ethers/utils';
-import {hashOutcome} from './outcome';
-import {encodeChannelStorageLite} from './channel-storage';
+import {hashOutcome} from '../outcome';
+import {encodeChannelStorageLite} from '../channel-storage';
 
 // TODO: Currently we are setting some arbitrary gas limit
 // to avoid issues with Ganache sendTransaction and parsing BN.js

--- a/src/transaction-creators/nitro-adjudicator.ts
+++ b/src/transaction-creators/nitro-adjudicator.ts
@@ -1,0 +1,38 @@
+// @ts-ignore
+import NitroAdjudicatorArtifact from '../../build/contracts/NitroAdjudicator.json';
+import {ethers} from 'ethers';
+import {TransactionRequest} from 'ethers/providers';
+import {State, hashState} from '../state';
+import {Outcome, encodeOutcome} from '../outcome';
+import {getChannelId} from '../channel';
+
+// TODO: Currently we are setting some arbitrary gas limit
+// to avoid issues with Ganache sendTransaction and parsing BN.js
+// If we don't set a gas limit some transactions will fail
+const GAS_LIMIT = 3000000;
+
+const NitroAdjudicatorContractInterface = new ethers.utils.Interface(NitroAdjudicatorArtifact.abi);
+
+export function createPushOutcomeTransaction(
+  turnNumRecord: number,
+  finalizesAt: string,
+  state: State,
+  outcome: Outcome,
+): TransactionRequest {
+  const channelId = getChannelId(state.channel);
+  const stateHash = hashState(state);
+  const {participants} = state.channel;
+  const challengerAddress = participants[state.turnNum % participants.length];
+  const encodedOutcome = encodeOutcome(outcome);
+
+  const data = NitroAdjudicatorContractInterface.functions.pushOutcome.encode([
+    channelId,
+    turnNumRecord,
+    finalizesAt,
+    stateHash,
+    challengerAddress,
+    encodedOutcome,
+  ]);
+
+  return {data, gasLimit: GAS_LIMIT};
+}

--- a/test/ForceMove/concludeFromChallenge.test.ts
+++ b/test/ForceMove/concludeFromChallenge.test.ts
@@ -22,7 +22,7 @@ import {
   hashChannelStorage,
   encodeChannelStorageLite,
 } from '../../src/channel-storage';
-import {createConcludeFromChallengeTransaction} from '../../src/force-move';
+import {createConcludeFromChallengeTransaction} from '../../src/transaction-creators/force-move';
 
 const provider = new ethers.providers.JsonRpcProvider(
   `http://localhost:${process.env.DEV_GANACHE_PORT}`,

--- a/test/ForceMove/concludeFromOpen.test.ts
+++ b/test/ForceMove/concludeFromOpen.test.ts
@@ -20,7 +20,7 @@ import {Outcome, hashOutcome} from '../../src/outcome';
 import {Channel, getChannelId} from '../../src/channel';
 import {State, hashState, getFixedPart, hashAppPart} from '../../src/state';
 import {Bytes32} from '../../src/types';
-import {createConcludeFromOpenTransaction} from '../../src/force-move';
+import {createConcludeFromOpenTransaction} from '../../src/transaction-creators/force-move';
 
 const provider = new ethers.providers.JsonRpcProvider(
   `http://localhost:${process.env.DEV_GANACHE_PORT}`,

--- a/test/ForceMove/forceMove.test.ts
+++ b/test/ForceMove/forceMove.test.ts
@@ -20,7 +20,7 @@ import {Channel, getChannelId} from '../../src/channel';
 import {State, getVariablePart, getFixedPart} from '../../src/state';
 import {hashChallengeMessage} from '../../src/challenge';
 import {hashChannelStorage, ChannelStorage} from '../../src/channel-storage';
-import {createForceMoveTransaction} from '../../src/force-move';
+import {createForceMoveTransaction} from '../../src/transaction-creators/force-move';
 
 const provider = new ethers.providers.JsonRpcProvider(
   `http://localhost:${process.env.DEV_GANACHE_PORT}`,
@@ -63,7 +63,6 @@ const description4 =
 const description5 = 'It reverts a forceMove when a challenge is underway / finalized';
 const description6 = 'It reverts a forceMove with an incorrect challengerSig';
 const description7 = 'It reverts a forceMove when the states do not form a validTransition chain';
-const description8 = 'It reverts when an unacceptable whoSignedWhat array is submitted';
 
 describe('forceMove', () => {
   it.each`
@@ -75,7 +74,6 @@ describe('forceMove', () => {
     ${description5} | ${205}       | ${ongoingChallengeHash(5)} | ${5}          | ${8}           | ${[2]}       | ${0}         | ${[0, 0, 0]}  | ${wallets[2]}     | ${'Channel is not open or turnNum does not match'}
     ${description6} | ${206}       | ${HashZero}                | ${0}          | ${8}           | ${[0, 1, 2]} | ${0}         | ${[0, 1, 2]}  | ${nonParticipant} | ${'Challenger is not a participant'}
     ${description7} | ${207}       | ${HashZero}                | ${0}          | ${8}           | ${[0, 1, 1]} | ${0}         | ${[0, 1, 2]}  | ${wallets[2]}     | ${'CountingApp: Counter must be incremented'}
-    ${description8} | ${208}       | ${HashZero}                | ${0}          | ${8}           | ${[0, 1, 2]} | ${0}         | ${[0, 0, 2]}  | ${wallets[2]}     | ${'Unacceptable whoSignedWhat array'}
   `(
     '$description', // for the purposes of this test, chainId and participants are fixed, making channelId 1-1 with channelNonce
     async ({

--- a/test/ForceMove/refute.test.ts
+++ b/test/ForceMove/refute.test.ts
@@ -11,7 +11,7 @@ import {Channel, getChannelId} from '../../src/channel';
 import {State, hashState, getFixedPart, getVariablePart} from '../../src/state';
 import {Outcome, hashOutcome} from '../../src/outcome';
 import {hashChannelStorage, ChannelStorage} from '../../src/channel-storage';
-import {createRefuteTransaction} from '../../src/force-move';
+import {createRefuteTransaction} from '../../src/transaction-creators/force-move';
 
 const provider = new ethers.providers.JsonRpcProvider(
   `http://localhost:${process.env.DEV_GANACHE_PORT}`,

--- a/test/ForceMove/respond.test.ts
+++ b/test/ForceMove/respond.test.ts
@@ -11,7 +11,7 @@ import {Outcome, hashOutcome} from '../../src/outcome';
 import {Channel, getChannelId} from '../../src/channel';
 import {State, hashState, getVariablePart, getFixedPart} from '../../src/state';
 import {hashChannelStorage} from '../../src/channel-storage';
-import {createRespondTransaction} from '../../src/force-move';
+import {createRespondTransaction} from '../../src/transaction-creators/force-move';
 
 const provider = new ethers.providers.JsonRpcProvider(
   `http://localhost:${process.env.DEV_GANACHE_PORT}`,

--- a/test/ForceMove/respondWithAlternative.test.ts
+++ b/test/ForceMove/respondWithAlternative.test.ts
@@ -17,7 +17,7 @@ import {Outcome} from '../../src/outcome';
 import {Channel, getChannelId} from '../../src/channel';
 import {State} from '../../src/state';
 import {hashChannelStorage} from '../../src/channel-storage';
-import {createRespondWithAlternativeTransaction} from '../../src/force-move';
+import {createRespondWithAlternativeTransaction} from '../../src/transaction-creators/force-move';
 
 const provider = new ethers.providers.JsonRpcProvider(
   `http://localhost:${process.env.DEV_GANACHE_PORT}`,

--- a/test/NitroAdjudicator/pushOutcome.test.ts
+++ b/test/NitroAdjudicator/pushOutcome.test.ts
@@ -7,17 +7,13 @@ import ETHAssetHolderArtifact from '../../build/contracts/ETHAssetHolder.json';
 import ERC20AssetHolderArtifact from '../../build/contracts/ERC20AssetHolder.json';
 
 import {AddressZero} from 'ethers/constants';
-import {setupContracts, finalizedOutcomeHash} from '../test-helpers';
+import {setupContracts, finalizedOutcomeHash, sendTransaction} from '../test-helpers';
 import {expectRevert} from 'magmo-devtools';
 import {Channel, getChannelId} from '../../src/channel';
-import {
-  Outcome,
-  hashOutcome,
-  AllocationOutcome,
-  encodeOutcome,
-  hashOutcomeContent,
-} from '../../src/outcome';
-import {State, hashState} from '../../src/state';
+import {hashOutcomeContent} from '../../src/outcome';
+import {State} from '../../src/state';
+import {createPushOutcomeTransaction} from '../../src//transaction-creators/nitro-adjudicator';
+import {toHex} from '../../src/hex-utils';
 
 const provider = new ethers.providers.JsonRpcProvider(
   `http://localhost:${process.env.DEV_GANACHE_PORT}`,
@@ -27,7 +23,7 @@ let ETHAssetHolder: ethers.Contract;
 let ERC20AssetHolder: ethers.Contract;
 
 // constants for this test suite
-const challengerAddress = AddressZero;
+
 const chainId = '0x1234';
 const participants = ['', '', ''];
 const wallets = new Array(3);
@@ -37,6 +33,7 @@ for (let i = 0; i < 3; i++) {
   wallets[i] = ethers.Wallet.createRandom();
   participants[i] = wallets[i].address;
 }
+const challengerAddress = participants[0];
 
 beforeAll(async () => {
   NitroAdjudicator = await setupContracts(provider, NitroAdjudicatorArtifact);
@@ -72,7 +69,7 @@ describe('pushOutcome', () => {
     }) => {
       const channel: Channel = {chainId, channelNonce, participants};
       const channelId = getChannelId(channel);
-      const finalizesAt = finalized ? 1 : 1e12; // either 1 second after genesis block, or ~ 31000 years after
+      const finalizesAt = finalized ? toHex(1) : toHex(1e12); // either 1 second after genesis block, or ~ 31000 years after
 
       const outcome = [
         {assetHolderAddress: ETHAssetHolder.address, allocation: []},
@@ -103,16 +100,15 @@ describe('pushOutcome', () => {
       expect(await NitroAdjudicator.channelStorageHashes(channelId)).toEqual(
         initialChannelStorageHash,
       );
+      const transactionRequest = createPushOutcomeTransaction(
+        declaredTurnNumRecord,
+        finalizesAt,
+        state,
+        outcome,
+      );
 
       if (outcomeHashExits) {
-        await (await NitroAdjudicator.pushOutcome(
-          channelId,
-          declaredTurnNumRecord,
-          finalizesAt,
-          hashState(state),
-          challengerAddress,
-          encodeOutcome(outcome),
-        )).wait();
+        await sendTransaction(provider, NitroAdjudicator.address, transactionRequest);
       }
 
       // call method in a slightly different way if expecting a revert
@@ -121,28 +117,11 @@ describe('pushOutcome', () => {
           '^' + 'VM Exception while processing transaction: revert ' + reasonString + '$',
         );
         await expectRevert(
-          () =>
-            NitroAdjudicator.pushOutcome(
-              channelId,
-              declaredTurnNumRecord,
-              finalizesAt,
-              hashState(state),
-              challengerAddress,
-              encodeOutcome(outcome),
-            ),
+          () => sendTransaction(provider, NitroAdjudicator.address, transactionRequest),
           regex,
         );
       } else {
-        const tx2 = await NitroAdjudicator.pushOutcome(
-          channelId,
-          declaredTurnNumRecord,
-          finalizesAt,
-          hashState(state),
-          challengerAddress,
-          encodeOutcome(outcome),
-        );
-        // wait for tx to be mined
-        await tx2.wait();
+        await sendTransaction(provider, NitroAdjudicator.address, transactionRequest);
         // check 2x AssetHolder storage against the expected value
         expect(await ETHAssetHolder.outcomeHashes(channelId)).toEqual(
           hashOutcomeContent(outcome[0].allocation),

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -20,6 +20,7 @@ import {
 } from '../src/outcome';
 import {State, hashState} from '../src/state';
 import {TransactionRequest} from 'ethers/providers';
+import {toHex} from '../src/hex-utils';
 
 export async function setupContracts(provider: ethers.providers.JsonRpcProvider, artifact) {
   const networkId = (await provider.getNetwork()).chainId;
@@ -55,14 +56,14 @@ export const ongoingChallengeHash = (turnNumRecord: number = 5) => {
 
 export const finalizedOutcomeHash = (
   turnNumRecord: number = 5,
-  finalizesAt: number = 1,
+  finalizesAt: string = toHex(1),
   challengerAddress: string = AddressZero,
   state?: State,
   outcome?: Outcome,
 ) => {
   return hashChannelStorage({
     largestTurnNum: bigNumberify(turnNumRecord).toHexString(),
-    finalizesAt: bigNumberify(finalizesAt).toHexString(),
+    finalizesAt,
     state,
     challengerAddress,
     outcome,


### PR DESCRIPTION
Adds a transaction creator for `pushOutcome` and switches the test to use it.