### PR TITLE
Shorten ConsensusApp.sol

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 contracts/AssetHolder.sol
+contracts/ConsensusApp.sol

--- a/contracts/ConsensusApp.sol
+++ b/contracts/ConsensusApp.sol
@@ -25,39 +25,29 @@ contract ConsensusApp is ForceMoveApp {
 
         if (identical(a.outcome, b.outcome)) {
             if (appDataB.furtherVotesRequired == numParticipants - 1) {
-                if // propose
-                    (
-                        appDataA.furtherVotesRequired == 0
-                    )
+                // propose
+                require(appDataA.furtherVotesRequired == 0);
+                return true;
+            } else if (appDataB.furtherVotesRequired == 0) {
+                // veto or pass
+                require(appDataB.proposedOutcome.length == 0);
+                return true;
+            } else if (appDataB.furtherVotesRequired == appDataA.furtherVotesRequired - 1) {
+                // vote
+                require(appDataA.furtherVotesRequired > 1);
+                require(identical(appDataA.proposedOutcome, appDataB.proposedOutcome));
                 return true;
             }
-            if (appDataB.furtherVotesRequired == 0) {
-                if // veto or pass
-                    (
-                        appDataB.proposedOutcome.length == 0
-                    )
-                return true;
-            }
-            if (appDataB.furtherVotesRequired == appDataA.furtherVotesRequired - 1) {
-                if // vote
-                    (
-                        appDataA.furtherVotesRequired > 1 &&
-                        identical(appDataA.proposedOutcome, appDataB.proposedOutcome)
-                    )
-                return true;
-            }
-        } else {
-            if // final vote
-                (
-                    identical(appDataA.proposedOutcome, b.outcome) &&
-                    appDataA.furtherVotesRequired == 1 &&
-                    appDataB.furtherVotesRequired == 0 &&
-                    appDataB.proposedOutcome.length == 0
-                )
+        } else { 
+            // final vote
+            require(identical(appDataA.proposedOutcome, b.outcome));
+            require(appDataA.furtherVotesRequired == 1);
+            require(appDataB.furtherVotesRequired == 0);
+            require(appDataB.proposedOutcome.length == 0);
             return true;
         }
-
         revert('ConsensusApp: No valid transition found');
+
     }
 
     // Utilitiy helpers

--- a/contracts/ConsensusApp.sol
+++ b/contracts/ConsensusApp.sol
@@ -4,237 +4,60 @@ pragma experimental ABIEncoderV2;
 import './ForceMoveApp.sol';
 
 contract ConsensusApp is ForceMoveApp {
-    struct ConsensusAppAttributes {
+    struct ConsensusAppData {
         uint32 furtherVotesRequired;
         bytes proposedOutcome;
     }
 
-    struct ConsensusCommitmentData {
-        uint32 furtherVotesRequired;
-        bytes currentOutcome;
-        bytes proposedOutcome;
+    function appData(bytes memory appDataBytes) internal pure returns (ConsensusAppData memory) {
+        return abi.decode(appDataBytes, (ConsensusAppData));
     }
 
     function validTransition(
-        VariablePart memory oldVariablePart,
-        VariablePart memory newVariablePart,
+        VariablePart memory a,
+        VariablePart memory b,
         uint256 turnNumB,
         uint256 numParticipants
     ) public pure returns (bool) {
-        ConsensusCommitmentData memory oldCommitmentData = fromVariablePart(oldVariablePart);
-        ConsensusCommitmentData memory newCommitmentData = fromVariablePart(newVariablePart);
 
-        if (oldCommitmentData.furtherVotesRequired == 0) {
-            validateConsensusCommitment(oldCommitmentData);
-        } else {
-            validateProposeCommitment(oldCommitmentData);
-        }
-
-        if (newCommitmentData.furtherVotesRequired == 0) {
-            validateConsensusCommitment(newCommitmentData);
-        } else {
-            validateProposeCommitment(newCommitmentData);
-        }
-
-        return
-            validPropose(oldCommitmentData, newCommitmentData, numParticipants) ||
-                validVote(oldCommitmentData, newCommitmentData) ||
-                validVeto(oldCommitmentData, newCommitmentData) ||
-                validPass(oldCommitmentData, newCommitmentData) ||
-                validFinalVote(oldCommitmentData, newCommitmentData) ||
-                invalidTransition();
-    }
-
-    // Helper converters
-
-    function fromVariablePart(VariablePart memory variablePart)
-        public
-        pure
-        returns (ConsensusCommitmentData memory)
-    {
-        ConsensusAppAttributes memory appAttributes = abi.decode(
-            variablePart.appData,
-            (ConsensusAppAttributes)
+        bool validPropose =
+        (
+            identical(a.outcome, b.outcome) &&
+            appData(a.appData).furtherVotesRequired == 0 &&
+            appData(b.appData).furtherVotesRequired == numParticipants - 1
+        );
+        
+        bool validVote =
+        (
+            identical(a.outcome, b.outcome) &&
+            appData(a.appData).furtherVotesRequired > 1 &&
+            appData(b.appData).furtherVotesRequired == appData(a.appData).furtherVotesRequired - 1 &&
+            identical(appData(a.appData).proposedOutcome, appData(b.appData).proposedOutcome)
         );
 
-        return
-            ConsensusCommitmentData(
-                appAttributes.furtherVotesRequired,
-                variablePart.outcome,
-                appAttributes.proposedOutcome
-            );
-    }
-
-    function invalidTransition() internal pure returns (bool) {
-        revert('ConsensusApp: No valid transition found for commitments');
-    }
-
-    // Transition validators
-
-    function validPropose(
-        ConsensusCommitmentData memory oldCommitmentData,
-        ConsensusCommitmentData memory newCommitmentData,
-        uint256 numParticipants
-    ) internal pure returns (bool) {
-        if (furtherVotesRequiredInitialized(newCommitmentData, numParticipants)) {
-            validateBalancesUnchanged(oldCommitmentData, newCommitmentData);
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    function validVote(
-        ConsensusCommitmentData memory oldCommitmentData,
-        ConsensusCommitmentData memory newCommitmentData
-    ) internal pure returns (bool) {
-        if (
-            oldCommitmentData.furtherVotesRequired > 1 &&
-            furtherVotesRequiredDecremented(oldCommitmentData, newCommitmentData)
-        ) {
-            validateBalancesUnchanged(oldCommitmentData, newCommitmentData);
-            validateProposalsUnchanged(oldCommitmentData, newCommitmentData);
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    function validVeto(
-        ConsensusCommitmentData memory oldCommitmentData,
-        ConsensusCommitmentData memory newCommitmentData
-    ) internal pure returns (bool) {
-        if (
-            oldCommitmentData.furtherVotesRequired > 0 &&
-            newCommitmentData.furtherVotesRequired == 0 &&
-            balancesUnchanged(oldCommitmentData, newCommitmentData)
-        ) {
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    function validFinalVote(
-        ConsensusCommitmentData memory oldCommitmentData,
-        ConsensusCommitmentData memory newCommitmentData
-    ) internal pure returns (bool) {
-        if (
-            oldCommitmentData.furtherVotesRequired == 1 &&
-            newCommitmentData.furtherVotesRequired == 0 &&
-            balancesUpdated(oldCommitmentData, newCommitmentData)
-        ) {
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    function validPass(
-        ConsensusCommitmentData memory oldCommitmentData,
-        ConsensusCommitmentData memory newCommitmentData
-    ) internal pure returns (bool) {
-        if (
-            oldCommitmentData.furtherVotesRequired == 0 &&
-            newCommitmentData.furtherVotesRequired == 0
-        ) {
-            validateBalancesUnchanged(oldCommitmentData, newCommitmentData);
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    // Helper validators
-
-    function validateConsensusCommitment(ConsensusCommitmentData memory commitmentData)
-        internal
-        pure
-    {
-        require(
-            commitmentData.furtherVotesRequired == 0,
-            "ConsensusApp: 'furtherVotesRequired' must be 0 during consensus."
+        bool validFinalVote =
+        (
+            appData(a.appData).furtherVotesRequired == 1 &&
+            appData(b.appData).furtherVotesRequired == 0 &&
+            identical(appData(a.appData).proposedOutcome, b.outcome) // &&
+            // identical(appData(b.appData).proposedOutcome, bytes32(0) ) TODO
         );
-        require(
-            commitmentData.proposedOutcome.length == 0,
-            "ConsensusApp: 'proposedOutcome' must be reset during consensus."
+
+        bool validVeto = // also covers validPass
+        (
+            identical(a.outcome, b.outcome) &&
+            appData(b.appData).furtherVotesRequired == 0 // &&
+            // appData(b.appData).proposedOutcome == bytes32(0) TODO
         );
-    }
 
-    function validateProposeCommitment(ConsensusCommitmentData memory commitmentData)
-        internal
-        pure
-    {
-        require(
-            commitmentData.furtherVotesRequired != 0,
-            "ConsensusApp: 'furtherVotesRequired' must not be 0 during propose."
-        );
-        require(
-            commitmentData.proposedOutcome.length > 0,
-            "ConsensusApp: 'proposedOutcome' must not be reset during propose."
-        );
-    }
-
-    function validateBalancesUnchanged(
-        ConsensusCommitmentData memory oldCommitmentData,
-        ConsensusCommitmentData memory newCommitmentData
-    ) private pure {
-        require(
-            encodeAndHashOutcome(oldCommitmentData.currentOutcome) ==
-                encodeAndHashOutcome(newCommitmentData.currentOutcome),
-            "ConsensusApp: 'outcome' must be the same between commitments."
-        );
-    }
-
-    function validateProposalsUnchanged(
-        ConsensusCommitmentData memory oldCommitmentData,
-        ConsensusCommitmentData memory newCommitmentData
-    ) private pure {
-        require(
-            encodeAndHashOutcome(oldCommitmentData.proposedOutcome) ==
-                encodeAndHashOutcome(newCommitmentData.proposedOutcome),
-            "ConsensusApp: 'proposedOutcome' must be the same between commitments."
-        );
-    }
-
-    // Booleans
-
-    function furtherVotesRequiredInitialized(
-        ConsensusCommitmentData memory appData,
-        uint256 numParticipants
-    ) private pure returns (bool) {
-        return (appData.furtherVotesRequired == numParticipants - 1);
-    }
-
-    function furtherVotesRequiredDecremented(
-        ConsensusCommitmentData memory oldCommitmentData,
-        ConsensusCommitmentData memory newCommitmentData
-    ) private pure returns (bool) {
-        return (newCommitmentData.furtherVotesRequired ==
-            oldCommitmentData.furtherVotesRequired - 1);
-    }
-
-    function balancesUnchanged(
-        ConsensusCommitmentData memory oldCommitmentData,
-        ConsensusCommitmentData memory newCommitmentData
-    ) private pure returns (bool) {
-        return
-            encodeAndHashOutcome(oldCommitmentData.currentOutcome) ==
-                encodeAndHashOutcome(newCommitmentData.currentOutcome);
-    }
-
-    function balancesUpdated(
-        ConsensusCommitmentData memory oldCommitmentData,
-        ConsensusCommitmentData memory newCommitmentData
-    ) private pure returns (bool) {
-        return (encodeAndHashOutcome(oldCommitmentData.proposedOutcome) ==
-            encodeAndHashOutcome(newCommitmentData.currentOutcome));
+        require((validPropose || validVote || validFinalVote || validVeto), 'ConsensusApp: No valid transition found');
+        return true;
     }
 
     // Utilitiy helpers
 
-    function encodeAndHashOutcome(bytes memory outcome) internal pure returns (bytes32) {
-        return keccak256(abi.encode(outcome));
+    function identical(bytes memory a, bytes memory b) internal pure returns (bool) {
+        return (keccak256(abi.encode(a)) == keccak256(abi.encode(b)));
     }
 
 }

--- a/contracts/ConsensusApp.sol
+++ b/contracts/ConsensusApp.sol
@@ -16,7 +16,7 @@ contract ConsensusApp is ForceMoveApp {
     function validTransition(
         VariablePart memory a,
         VariablePart memory b,
-        uint256 turnNumB,
+        uint256 turnNumB, // unused
         uint256 numParticipants
     ) public pure returns (bool) {
 

--- a/contracts/ConsensusApp.sol
+++ b/contracts/ConsensusApp.sol
@@ -30,7 +30,7 @@ contract ConsensusApp is ForceMoveApp {
                 return true;
             } else if (appDataB.furtherVotesRequired == 0) {
                 // veto or pass
-                require(appDataB.proposedOutcome.length == 0, 'ConsensusApp: invalid veto or invalid pass, proposeOutcome must transition to null');
+                require(appDataB.proposedOutcome.length == 0, 'ConsensusApp: invalid veto or invalid pass, proposedOutcome must transition to empty');
                 return true;
             } else if (appDataB.furtherVotesRequired == appDataA.furtherVotesRequired - 1) {
                 // vote
@@ -40,10 +40,10 @@ contract ConsensusApp is ForceMoveApp {
             }
         } else { 
             // final vote
-            require(identical(appDataA.proposedOutcome, b.outcome), 'ConsensusApp: invalid final vote, outcome must reflect previous proposedOutcome');
+            require(identical(appDataA.proposedOutcome, b.outcome), 'ConsensusApp: invalid final vote, outcome must equal previous proposedOutcome');
             require(appDataA.furtherVotesRequired == 1,'ConsensusApp: invalid final vote, furtherVotesRequired must transition from 1');
             require(appDataB.furtherVotesRequired == 0,'ConsensusApp: invalid final vote, furtherVotesRequired must transition to 0');
-            require(appDataB.proposedOutcome.length == 0,'ConsensusApp: invalid final vote, proposedOutcome must transition to null');
+            require(appDataB.proposedOutcome.length == 0,'ConsensusApp: invalid final vote, proposedOutcome must transition to empty');
             return true;
         }
         revert('ConsensusApp: outcome must either be preserved or transition to previous proposedOutcome');

--- a/contracts/ConsensusApp.sol
+++ b/contracts/ConsensusApp.sol
@@ -26,27 +26,27 @@ contract ConsensusApp is ForceMoveApp {
         if (identical(a.outcome, b.outcome)) {
             if (appDataB.furtherVotesRequired == numParticipants - 1) {
                 // propose
-                require(appDataA.furtherVotesRequired == 0);
+                require(appDataA.furtherVotesRequired == 0, 'ConsensusApp: invalid propose, furtherVotesRequired must be transition from zero');
                 return true;
             } else if (appDataB.furtherVotesRequired == 0) {
                 // veto or pass
-                require(appDataB.proposedOutcome.length == 0);
+                require(appDataB.proposedOutcome.length == 0, 'ConsensusApp: invalid veto or invalid pass, proposeOutcome must transition to null');
                 return true;
             } else if (appDataB.furtherVotesRequired == appDataA.furtherVotesRequired - 1) {
                 // vote
-                require(appDataA.furtherVotesRequired > 1);
-                require(identical(appDataA.proposedOutcome, appDataB.proposedOutcome));
+                require(appDataA.furtherVotesRequired > 1,'ConsensusApp: invalid vote, furtherVotesRequired must transition from at least 2');
+                require(identical(appDataA.proposedOutcome, appDataB.proposedOutcome), 'ConsensusApp: invalid vote, proposedOutcome must not change');
                 return true;
             }
         } else { 
             // final vote
-            require(identical(appDataA.proposedOutcome, b.outcome));
-            require(appDataA.furtherVotesRequired == 1);
-            require(appDataB.furtherVotesRequired == 0);
-            require(appDataB.proposedOutcome.length == 0);
+            require(identical(appDataA.proposedOutcome, b.outcome), 'ConsensusApp: invalid final vote, outcome must reflect previous proposedOutcome');
+            require(appDataA.furtherVotesRequired == 1,'ConsensusApp: invalid final vote, furtherVotesRequired must transition from 1');
+            require(appDataB.furtherVotesRequired == 0,'ConsensusApp: invalid final vote, furtherVotesRequired must transition to 0');
+            require(appDataB.proposedOutcome.length == 0,'ConsensusApp: invalid final vote, proposedOutcome must transition to null');
             return true;
         }
-        revert('ConsensusApp: No valid transition found');
+        revert('ConsensusApp: outcome must either be preserved or transition to previous proposedOutcome');
 
     }
 

--- a/contracts/ConsensusApp.sol
+++ b/contracts/ConsensusApp.sol
@@ -20,34 +20,37 @@ contract ConsensusApp is ForceMoveApp {
         uint256 numParticipants
     ) public pure returns (bool) {
 
+        ConsensusAppData memory appDataA = appData(a.appData);
+        ConsensusAppData memory appDataB = appData(b.appData);
+
         bool validPropose =
         (
             identical(a.outcome, b.outcome) &&
-            appData(a.appData).furtherVotesRequired == 0 &&
-            appData(b.appData).furtherVotesRequired == numParticipants - 1
+            appDataA.furtherVotesRequired == 0 &&
+            appDataB.furtherVotesRequired == numParticipants - 1
         );
         
         bool validVote =
         (
             identical(a.outcome, b.outcome) &&
-            appData(a.appData).furtherVotesRequired > 1 &&
-            appData(b.appData).furtherVotesRequired == appData(a.appData).furtherVotesRequired - 1 &&
-            identical(appData(a.appData).proposedOutcome, appData(b.appData).proposedOutcome)
+            appDataA.furtherVotesRequired > 1 &&
+            appDataB.furtherVotesRequired == appDataA.furtherVotesRequired - 1 &&
+            identical(appDataA.proposedOutcome, appDataB.proposedOutcome)
         );
 
         bool validFinalVote =
         (
-            appData(a.appData).furtherVotesRequired == 1 &&
-            appData(b.appData).furtherVotesRequired == 0 &&
-            identical(appData(a.appData).proposedOutcome, b.outcome) &&
-            appData(b.appData).proposedOutcome.length == 0
+            appDataA.furtherVotesRequired == 1 &&
+            appDataB.furtherVotesRequired == 0 &&
+            identical(appDataA.proposedOutcome, b.outcome) &&
+            appDataB.proposedOutcome.length == 0
         );
 
         bool validVeto = // also covers validPass
         (
             identical(a.outcome, b.outcome) &&
-            appData(b.appData).furtherVotesRequired == 0 &&
-            appData(b.appData).proposedOutcome.length == 0
+            appDataB.furtherVotesRequired == 0 &&
+            appDataB.proposedOutcome.length == 0
         );
 
         require((validPropose || validVote || validFinalVote || validVeto), 'ConsensusApp: No valid transition found');

--- a/contracts/ConsensusApp.sol
+++ b/contracts/ConsensusApp.sol
@@ -32,14 +32,14 @@ contract ConsensusApp is ForceMoveApp {
                 return true;
             }
             if (appDataB.furtherVotesRequired == 0) {
-                if // validVeto & validPass
+                if // veto or pass
                     (
                         appDataB.proposedOutcome.length == 0
                     )
                 return true;
             }
             if (appDataB.furtherVotesRequired == appDataA.furtherVotesRequired - 1) {
-                if // validVote
+                if // vote
                     (
                         appDataA.furtherVotesRequired > 1 &&
                         identical(appDataA.proposedOutcome, appDataB.proposedOutcome)
@@ -47,7 +47,7 @@ contract ConsensusApp is ForceMoveApp {
                 return true;
             }
         } else {
-            if // validFinalVote
+            if // final vote
                 (
                     identical(appDataA.proposedOutcome, b.outcome) &&
                     appDataA.furtherVotesRequired == 1 &&

--- a/contracts/ConsensusApp.sol
+++ b/contracts/ConsensusApp.sol
@@ -39,15 +39,15 @@ contract ConsensusApp is ForceMoveApp {
         (
             appData(a.appData).furtherVotesRequired == 1 &&
             appData(b.appData).furtherVotesRequired == 0 &&
-            identical(appData(a.appData).proposedOutcome, b.outcome) // &&
-            // identical(appData(b.appData).proposedOutcome, bytes32(0) ) TODO
+            identical(appData(a.appData).proposedOutcome, b.outcome) &&
+            appData(b.appData).proposedOutcome.length == 0
         );
 
         bool validVeto = // also covers validPass
         (
             identical(a.outcome, b.outcome) &&
-            appData(b.appData).furtherVotesRequired == 0 // &&
-            // appData(b.appData).proposedOutcome == bytes32(0) TODO
+            appData(b.appData).furtherVotesRequired == 0 &&
+            appData(b.appData).proposedOutcome.length == 0
         );
 
         require((validPropose || validVote || validFinalVote || validVeto), 'ConsensusApp: No valid transition found');

--- a/contracts/ConsensusApp.sol
+++ b/contracts/ConsensusApp.sol
@@ -23,38 +23,41 @@ contract ConsensusApp is ForceMoveApp {
         ConsensusAppData memory appDataA = appData(a.appData);
         ConsensusAppData memory appDataB = appData(b.appData);
 
-        bool validPropose =
+        if // propose
         (
             identical(a.outcome, b.outcome) &&
             appDataA.furtherVotesRequired == 0 &&
             appDataB.furtherVotesRequired == numParticipants - 1
-        );
+        )
+        {return true;}
         
-        bool validVote =
+        if // validVote 
         (
             identical(a.outcome, b.outcome) &&
             appDataA.furtherVotesRequired > 1 &&
             appDataB.furtherVotesRequired == appDataA.furtherVotesRequired - 1 &&
             identical(appDataA.proposedOutcome, appDataB.proposedOutcome)
-        );
+        )
+        {return true;}
 
-        bool validFinalVote =
+        if // validFinalVote =
         (
             appDataA.furtherVotesRequired == 1 &&
             appDataB.furtherVotesRequired == 0 &&
             identical(appDataA.proposedOutcome, b.outcome) &&
             appDataB.proposedOutcome.length == 0
-        );
+        )
+        {return true;}
 
-        bool validVeto = // also covers validPass
+        if // validVeto & validPass
         (
             identical(a.outcome, b.outcome) &&
             appDataB.furtherVotesRequired == 0 &&
             appDataB.proposedOutcome.length == 0
-        );
+        )
+        {return true;}
 
-        require((validPropose || validVote || validFinalVote || validVeto), 'ConsensusApp: No valid transition found');
-        return true;
+        revert('ConsensusApp: No valid transition found');
     }
 
     // Utilitiy helpers

--- a/contracts/ConsensusApp.sol
+++ b/contracts/ConsensusApp.sol
@@ -23,39 +23,39 @@ contract ConsensusApp is ForceMoveApp {
         ConsensusAppData memory appDataA = appData(a.appData);
         ConsensusAppData memory appDataB = appData(b.appData);
 
-        if // propose
-        (
-            identical(a.outcome, b.outcome) &&
-            appDataA.furtherVotesRequired == 0 &&
-            appDataB.furtherVotesRequired == numParticipants - 1
-        )
-        {return true;}
-        
-        if // validVote 
-        (
-            identical(a.outcome, b.outcome) &&
-            appDataA.furtherVotesRequired > 1 &&
-            appDataB.furtherVotesRequired == appDataA.furtherVotesRequired - 1 &&
-            identical(appDataA.proposedOutcome, appDataB.proposedOutcome)
-        )
-        {return true;}
-
-        if // validFinalVote =
-        (
-            appDataA.furtherVotesRequired == 1 &&
-            appDataB.furtherVotesRequired == 0 &&
-            identical(appDataA.proposedOutcome, b.outcome) &&
-            appDataB.proposedOutcome.length == 0
-        )
-        {return true;}
-
-        if // validVeto & validPass
-        (
-            identical(a.outcome, b.outcome) &&
-            appDataB.furtherVotesRequired == 0 &&
-            appDataB.proposedOutcome.length == 0
-        )
-        {return true;}
+        if (identical(a.outcome, b.outcome)) {
+            if (appDataB.furtherVotesRequired == numParticipants - 1) {
+                if // propose
+                    (
+                        appDataA.furtherVotesRequired == 0
+                    )
+                return true;
+            }
+            if (appDataB.furtherVotesRequired == 0) {
+                if // validVeto & validPass
+                    (
+                        appDataB.proposedOutcome.length == 0
+                    )
+                return true;
+            }
+            if (appDataB.furtherVotesRequired == appDataA.furtherVotesRequired - 1) {
+                if // validVote
+                    (
+                        appDataA.furtherVotesRequired > 1 &&
+                        identical(appDataA.proposedOutcome, appDataB.proposedOutcome)
+                    )
+                return true;
+            }
+        } else {
+            if // validFinalVote
+                (
+                    identical(appDataA.proposedOutcome, b.outcome) &&
+                    appDataA.furtherVotesRequired == 1 &&
+                    appDataB.furtherVotesRequired == 0 &&
+                    appDataB.proposedOutcome.length == 0
+                )
+            return true;
+        }
 
         revert('ConsensusApp: No valid transition found');
     }

--- a/test/ConsensusApp/validTransition.test.ts
+++ b/test/ConsensusApp/validTransition.test.ts
@@ -87,6 +87,15 @@ describe('validTransition', () => {
     );
   });
 
+  it('invalid veto: proposedOutcome not empty', async () => {
+    const variablePartOld = constructConsensusVariablePart(2, defaultOutcome1, defaultOutcome2);
+    const variablePartNew = constructConsensusVariablePart(0, defaultOutcome1, defaultOutcome2);
+    await expectRevert(
+      () => consensusApp.validTransition(variablePartOld, variablePartNew, defaultTurn, 3),
+      noValidTransitionError,
+    );
+  });
+
   it('valid pass', async () => {
     const variablePartOld = constructConsensusVariablePart(0, defaultOutcome1, emptyOutcome);
     const variablePartNew = constructConsensusVariablePart(0, defaultOutcome1, emptyOutcome);
@@ -115,6 +124,15 @@ describe('validTransition', () => {
   it('invalid finalVote: proposedOutcome1 ≠ currentOutcome2', async () => {
     const variablePartOld = constructConsensusVariablePart(1, defaultOutcome1, defaultOutcome2);
     const variablePartNew = constructConsensusVariablePart(0, defaultOutcome3, emptyOutcome);
+    await expectRevert(
+      () => consensusApp.validTransition(variablePartOld, variablePartNew, defaultTurn, 3),
+      noValidTransitionError,
+    );
+  });
+
+  it('invalid finalVote: proposedOutcome not empty', async () => {
+    const variablePartOld = constructConsensusVariablePart(1, defaultOutcome1, defaultOutcome2);
+    const variablePartNew = constructConsensusVariablePart(0, defaultOutcome2, defaultOutcome2);
     await expectRevert(
       () => consensusApp.validTransition(variablePartOld, variablePartNew, defaultTurn, 3),
       noValidTransitionError,

--- a/test/ConsensusApp/validTransition.test.ts
+++ b/test/ConsensusApp/validTransition.test.ts
@@ -75,7 +75,7 @@ describe('validTransition', () => {
     );
     if (reason) {
       await expectRevert(
-        () => consensusApp.validTransition(variablePartOld, variablePartNew, defaultTurn, 3),
+        () => consensusApp.validTransition(variablePartOld, variablePartNew, turnNumB, 3),
         noValidTransitionError,
       );
     } else {

--- a/test/ConsensusApp/validTransition.test.ts
+++ b/test/ConsensusApp/validTransition.test.ts
@@ -106,5 +106,4 @@ async function sendTransaction(contractAddress: string, transaction: Transaction
   const signer = provider.getSigner();
   const response = await signer.sendTransaction({to: contractAddress, ...transaction});
   await response.wait();
-  return response;
 }

--- a/test/ConsensusApp/validTransition.test.ts
+++ b/test/ConsensusApp/validTransition.test.ts
@@ -15,135 +15,10 @@ interface ConsensusAppVariablePart {
   outcome: string;
 }
 
-// constant values
-const emptyOutcome = '0x';
-const defaultOutcome1 = '0x1';
-const defaultOutcome2 = '0x2';
-const defaultOutcome3 = '0x3';
-
-const defaultTurn = 1;
-
-const noValidTransitionError = 'ConsensusApp: No valid transition found';
-
-beforeAll(async () => {
-  consensusApp = await setupContracts(provider, ConsensusAppArtifact);
-});
-
-describe('validTransition', () => {
-  it('valid consensus -> propose', async () => {
-    const variablePartOld = constructConsensusVariablePart(0, defaultOutcome1, emptyOutcome);
-    const variablePartNew = constructConsensusVariablePart(2);
-    const isValid = await consensusApp.validTransition(
-      variablePartOld,
-      variablePartNew,
-      defaultTurn,
-      3,
-    );
-    expect(isValid).toBe(true);
-  });
-
-  it('invalid consensus -> propose: furtherVotesRequired too low', async () => {
-    const variablePartOld = constructConsensusVariablePart(0, defaultOutcome1, emptyOutcome);
-    const variablePartNew = constructConsensusVariablePart(1, defaultOutcome1, defaultOutcome1);
-
-    await expectRevert(
-      () => consensusApp.validTransition(variablePartOld, variablePartNew, defaultTurn, 3),
-      noValidTransitionError,
-    );
-  });
-
-  it('valid vote', async () => {
-    const variablePartOld = constructConsensusVariablePart(2);
-    const variablePartNew = constructConsensusVariablePart(1);
-    expect(
-      await consensusApp.validTransition(variablePartOld, variablePartNew, defaultTurn, 3),
-    ).toBe(true);
-  });
-
-  it('invalid vote: furtherVotesRequired not decreased', async () => {
-    const variablePartOld = constructConsensusVariablePart(2);
-    const variablePartNew = constructConsensusVariablePart(2);
-
-    await expectRevert(
-      () => consensusApp.validTransition(variablePartOld, variablePartNew, defaultTurn, 4),
-      noValidTransitionError,
-    );
-  });
-
-  it('valid veto', async () => {
-    const variablePartOld = constructConsensusVariablePart(2, defaultOutcome1, defaultOutcome2);
-    const variablePartNew = constructConsensusVariablePart(0, defaultOutcome1, emptyOutcome);
-    expect(
-      await consensusApp.validTransition(variablePartOld, variablePartNew, defaultTurn, 3),
-    ).toBe(true);
-  });
-
-  it('invalid veto: currentOutcome1 ≠ currentOutcome2', async () => {
-    const variablePartOld = constructConsensusVariablePart(2, defaultOutcome1, defaultOutcome2);
-    const variablePartNew = constructConsensusVariablePart(0, defaultOutcome2, emptyOutcome);
-    await expectRevert(
-      () => consensusApp.validTransition(variablePartOld, variablePartNew, defaultTurn, 3),
-      noValidTransitionError,
-    );
-  });
-
-  it('invalid veto: proposedOutcome not empty', async () => {
-    const variablePartOld = constructConsensusVariablePart(2, defaultOutcome1, defaultOutcome2);
-    const variablePartNew = constructConsensusVariablePart(0, defaultOutcome1, defaultOutcome2);
-    await expectRevert(
-      () => consensusApp.validTransition(variablePartOld, variablePartNew, defaultTurn, 3),
-      noValidTransitionError,
-    );
-  });
-
-  it('valid pass', async () => {
-    const variablePartOld = constructConsensusVariablePart(0, defaultOutcome1, emptyOutcome);
-    const variablePartNew = constructConsensusVariablePart(0, defaultOutcome1, emptyOutcome);
-    expect(
-      await consensusApp.validTransition(variablePartOld, variablePartNew, defaultTurn, 3),
-    ).toBe(true);
-  });
-
-  it('invalid pass: currentOutcome1 ≠ currentOutcome2', async () => {
-    const variablePartOld = constructConsensusVariablePart(0, defaultOutcome1, emptyOutcome);
-    const variablePartNew = constructConsensusVariablePart(0, defaultOutcome2, emptyOutcome);
-    await expectRevert(
-      () => consensusApp.validTransition(variablePartOld, variablePartNew, defaultTurn, 3),
-      noValidTransitionError,
-    );
-  });
-
-  it('valid finalVote', async () => {
-    const variablePartOld = constructConsensusVariablePart(1, defaultOutcome1, defaultOutcome2);
-    const variablePartNew = constructConsensusVariablePart(0, defaultOutcome2, emptyOutcome);
-    expect(
-      await consensusApp.validTransition(variablePartOld, variablePartNew, defaultTurn, 3),
-    ).toBe(true);
-  });
-
-  it('invalid finalVote: proposedOutcome1 ≠ currentOutcome2', async () => {
-    const variablePartOld = constructConsensusVariablePart(1, defaultOutcome1, defaultOutcome2);
-    const variablePartNew = constructConsensusVariablePart(0, defaultOutcome3, emptyOutcome);
-    await expectRevert(
-      () => consensusApp.validTransition(variablePartOld, variablePartNew, defaultTurn, 3),
-      noValidTransitionError,
-    );
-  });
-
-  it('invalid finalVote: proposedOutcome not empty', async () => {
-    const variablePartOld = constructConsensusVariablePart(1, defaultOutcome1, defaultOutcome2);
-    const variablePartNew = constructConsensusVariablePart(0, defaultOutcome2, defaultOutcome2);
-    await expectRevert(
-      () => consensusApp.validTransition(variablePartOld, variablePartNew, defaultTurn, 3),
-      noValidTransitionError,
-    );
-  });
-});
-
 function constructConsensusVariablePart(
   furtherVotesRequired: number,
-  currentOutcome: string = defaultOutcome1,
-  proposedOutcome: string = defaultOutcome1,
+  currentOutcome,
+  proposedOutcome,
 ): ConsensusAppVariablePart {
   const appData: string = defaultAbiCoder.encode(
     ['tuple(uint32, bytes)'],
@@ -151,3 +26,66 @@ function constructConsensusVariablePart(
   );
   return {appData, outcome: currentOutcome};
 }
+
+const turnNumB = 1; // not checked by contract
+const numParticipants = 3;
+
+const noValidTransitionError = 'ConsensusApp: No valid transition found';
+
+beforeAll(async () => {
+  consensusApp = await setupContracts(provider, ConsensusAppArtifact);
+});
+
+const description00 = 'valid consensus -> propose';
+const description01 = 'invalid consensus -> propose: furtherVotesRequired too low';
+const description02 = 'valid vote';
+const description03 = 'invalid vote: furtherVotesRequired not decreased';
+const description04 = 'valid veto';
+const description05 = 'invalid veto: proposedOutcome not empty';
+const description06 = 'valid pass';
+const description07 = 'invalid pass: currentOutcome1 ≠ currentOutcome2';
+const description08 = 'valid finalVote';
+const description09 = 'invalid finalVote: proposedOutcome1 ≠ currentOutcome2';
+const description10 = 'invalid finalVote: proposedOutcome not empty';
+
+describe('validTransition', () => {
+  it.each`
+    description      | furtherVotesRequired | outcome           | proposedOutcome   | reason
+    ${description00} | ${[0, 2]}            | ${['0x1', '0x1']} | ${['0x', '0x1']}  | ${undefined}
+    ${description01} | ${[0, 1]}            | ${['0x1', '0x1']} | ${['0x', '0x1']}  | ${noValidTransitionError}
+    ${description02} | ${[2, 1]}            | ${['0x1', '0x1']} | ${['0x1', '0x1']} | ${undefined}
+    ${description03} | ${[2, 2]}            | ${['0x1', '0x1']} | ${['0x1', '0x1']} | ${noValidTransitionError}
+    ${description04} | ${[2, 0]}            | ${['0x1', '0x1']} | ${['0x2', '0x']}  | ${undefined}
+    ${description05} | ${[2, 0]}            | ${['0x1', '0x2']} | ${['0x2', '0x']}  | ${noValidTransitionError}
+    ${description06} | ${[0, 0]}            | ${['0x1', '0x1']} | ${['0x', '0x']}   | ${undefined}
+    ${description07} | ${[0, 0]}            | ${['0x1', '0x2']} | ${['0x', '0x']}   | ${noValidTransitionError}
+    ${description08} | ${[1, 0]}            | ${['0x1', '0x2']} | ${['0x2', '0x']}  | ${undefined}
+    ${description09} | ${[1, 0]}            | ${['0x1', '0x3']} | ${['0x2', '0x']}  | ${noValidTransitionError}
+    ${description10} | ${[1, 0]}            | ${['0x1', '0x2']} | ${['0x2', '0x2']} | ${noValidTransitionError}
+  `('$description', async ({furtherVotesRequired, outcome, proposedOutcome, reason}) => {
+    const variablePartOld = constructConsensusVariablePart(
+      furtherVotesRequired[0],
+      outcome[0],
+      proposedOutcome[0],
+    );
+    const variablePartNew = constructConsensusVariablePart(
+      furtherVotesRequired[1],
+      outcome[1],
+      proposedOutcome[1],
+    );
+    if (reason) {
+      await expectRevert(
+        () => consensusApp.validTransition(variablePartOld, variablePartNew, defaultTurn, 3),
+        noValidTransitionError,
+      );
+    } else {
+      const isValid = await consensusApp.validTransition(
+        variablePartOld,
+        variablePartNew,
+        turnNumB,
+        numParticipants,
+      );
+      expect(isValid).toBe(true);
+    }
+  });
+});

--- a/test/ConsensusApp/validTransition.test.ts
+++ b/test/ConsensusApp/validTransition.test.ts
@@ -65,20 +65,20 @@ describe('validTransition', () => {
     ${description09} | ${[1, 0]}            | ${['0x1', '0x3']} | ${['0x2', '0x']}  | ${noValidTransitionError}
     ${description10} | ${[1, 0]}            | ${['0x1', '0x2']} | ${['0x2', '0x2']} | ${noValidTransitionError}
   `('$description', async ({furtherVotesRequired, outcome, proposedOutcome, reason}) => {
-    const variablePartOld = constructConsensusVariablePart(
+    const variablePartA = constructConsensusVariablePart(
       furtherVotesRequired[0],
       outcome[0],
       proposedOutcome[0],
     );
-    const variablePartNew = constructConsensusVariablePart(
+    const variablePartB = constructConsensusVariablePart(
       furtherVotesRequired[1],
       outcome[1],
       proposedOutcome[1],
     );
     const transactionRequest = {
       data: ConsensusAppContractInterface.functions.validTransition.encode([
-        variablePartOld,
-        variablePartNew,
+        variablePartA,
+        variablePartB,
         turnNumB,
         numParticipants,
       ]),
@@ -91,8 +91,8 @@ describe('validTransition', () => {
 
       // just call the function, so we can check the return value easily
       const isValid = await consensusApp.validTransition(
-        variablePartOld,
-        variablePartNew,
+        variablePartA,
+        variablePartB,
         turnNumB,
         numParticipants,
       );

--- a/test/ConsensusApp/validTransition.test.ts
+++ b/test/ConsensusApp/validTransition.test.ts
@@ -23,8 +23,7 @@ const defaultOutcome3 = '0x3';
 
 const defaultTurn = 1;
 
-const noValidTransitionError = 'ConsensusApp: No valid transition found for commitments';
-const outcomeMustBeSameError = "ConsensusApp: 'outcome' must be the same between commitments.";
+const noValidTransitionError = 'ConsensusApp: No valid transition found';
 
 beforeAll(async () => {
   consensusApp = await setupContracts(provider, ConsensusAppArtifact);
@@ -101,7 +100,7 @@ describe('validTransition', () => {
     const variablePartNew = constructConsensusVariablePart(0, defaultOutcome2, emptyOutcome);
     await expectRevert(
       () => consensusApp.validTransition(variablePartOld, variablePartNew, defaultTurn, 3),
-      outcomeMustBeSameError,
+      noValidTransitionError,
     );
   });
 


### PR DESCRIPTION
Designed to function identically (gas consumption notwithstanding), but to aid readability and reflect the underlying simplicity of the consensus game.

This PR also:
- converts the test over to the `it.each` table format. 
- sends transactions in the tests, so that we can measure gas usage.

It turns out that the first iteration of the shorter contract actually uses slightly more gas. 

By exploiting [this observation](https://github.com/statechannels/nitro-protocol/blob/e84e5031259da271e85ef33a39a1fb827843fdd4/docs/force-move/consensus-game.md): `Note: either a transition is a veto, or you can switch on furtherVotesRequired to determine which of cases 1-3 it is.`, the gas cost slightly decreased. 

```
Contract Name           Method Name      Calls  Min Gas  Max Gas  Average Gas
----------------------  ---------------  -----  -------  -------  -----------
ConsensusApp (long)    validTransition  11     32152    35137    33720  
ConsensusApp (short)   validTransition  11     32326    36479    34944         
ConsensusApp (shortv2) validTransition  11     31925    34026    33049   
ConsensusApp (shortv3) validTransition  11     31929    34017    32914      
ConsensusApp (shortv4*)validTransition  11     31929    34017    33041

* includes `require` statements
```