### PR TITLE
Simpler consensus game

### DIFF
--- a/contracts/ConsensusApp.sol
+++ b/contracts/ConsensusApp.sol
@@ -24,7 +24,7 @@ contract ConsensusApp is ForceMoveApp {
         ConsensusAppData memory appDataB = appData(b.appData);
 
         if(appDataB.furtherVotesRequired == numParticipants - 1) { // propose/veto/pass
-            require(identical(a.outcome, b.outcome), 'ConsensusApp: when proposing/vetoing outcome must not change');
+            require(identical(a.outcome, b.outcome), 'ConsensusApp: when proposing/vetoing/passing outcome must not change');
         } else if (appDataB.furtherVotesRequired == 0 ) { // final vote
             require(appDataA.furtherVotesRequired == 1,'ConsensusApp: invalid final vote, furtherVotesRequired must transition from 1');
             require(identical(appDataA.proposedOutcome, b.outcome), 'ConsensusApp: invalid final vote, outcome must equal previous proposedOutcome');

--- a/contracts/ConsensusApp.sol
+++ b/contracts/ConsensusApp.sol
@@ -23,31 +23,17 @@ contract ConsensusApp is ForceMoveApp {
         ConsensusAppData memory appDataA = appData(a.appData);
         ConsensusAppData memory appDataB = appData(b.appData);
 
-        if (identical(a.outcome, b.outcome)) {
-            if (appDataB.furtherVotesRequired == numParticipants - 1) {
-                // propose
-                require(appDataA.furtherVotesRequired == 0, 'ConsensusApp: invalid propose, furtherVotesRequired must be transition from zero');
-                return true;
-            } else if (appDataB.furtherVotesRequired == 0) {
-                // veto or pass
-                require(appDataB.proposedOutcome.length == 0, 'ConsensusApp: invalid veto or invalid pass, proposedOutcome must transition to empty');
-                return true;
-            } else if (appDataB.furtherVotesRequired == appDataA.furtherVotesRequired - 1) {
-                // vote
-                require(appDataA.furtherVotesRequired > 1,'ConsensusApp: invalid vote, furtherVotesRequired must transition from at least 2');
-                require(identical(appDataA.proposedOutcome, appDataB.proposedOutcome), 'ConsensusApp: invalid vote, proposedOutcome must not change');
-                return true;
-            }
-        } else { 
-            // final vote
-            require(identical(appDataA.proposedOutcome, b.outcome), 'ConsensusApp: invalid final vote, outcome must equal previous proposedOutcome');
+        if(appDataB.furtherVotesRequired == numParticipants - 1) { // propose/veto/pass
+            require(identical(a.outcome, b.outcome), 'ConsensusApp: when proposing/vetoing outcome must not change');
+        } else if (appDataB.furtherVotesRequired == 0 ) { // final vote
             require(appDataA.furtherVotesRequired == 1,'ConsensusApp: invalid final vote, furtherVotesRequired must transition from 1');
-            require(appDataB.furtherVotesRequired == 0,'ConsensusApp: invalid final vote, furtherVotesRequired must transition to 0');
-            require(appDataB.proposedOutcome.length == 0,'ConsensusApp: invalid final vote, proposedOutcome must transition to empty');
-            return true;
+            require(identical(appDataA.proposedOutcome, b.outcome), 'ConsensusApp: invalid final vote, outcome must equal previous proposedOutcome');
+        } else { // vote
+            require(appDataB.furtherVotesRequired == appDataA.furtherVotesRequired - 1, 'ConsensusApp: invalid vote, furtherVotesRequired should decrement');
+            require(identical(a.outcome, b.outcome), 'ConsensusApp: when voting, outcome must not change');
+            require(identical(appDataA.proposedOutcome, appDataB.proposedOutcome), 'ConsensusApp: invalid vote, proposedOutcome must not change');
         }
-        revert('ConsensusApp: outcome must either be preserved or transition to previous proposedOutcome');
-
+        return true;
     }
 
     // Utilitiy helpers

--- a/docs/force-move/consensus-game.md
+++ b/docs/force-move/consensus-game.md
@@ -18,9 +18,8 @@ The app also has access to the `currentOutcome`, which is passed through with th
 
 The allowed transitions are:
 
-1. Propose: `(0, w, -) -> (n-1, w, w')`
+1. Propose: `(i, w, -) -> (n-1, w, w')`
    - oldState.currentOutcome == newState.currentOutcome
-   - oldState.data.furtherVotesRequired == 0
    - newState.furtherVotesRequired == nParticipants - 1
 2. Vote: `(i+1, w, w') -> (i, w, w')`
    - oldState.furtherVotesRequired > 1
@@ -31,13 +30,12 @@ The allowed transitions are:
    - oldState.furtherVotesRequired == 1
    - newState.furtherVotesRequired == 0
    - newState.currentOutcome == oldState.proposedOutcome
-   - newState.proposedOutcome is empty
-4. Veto: `(i, w, w') -> (0, w, -)`
-   - newState.furtherVotesRequired == 0
-   - newState.currentOutcome = oldState.currentOutcome
-   - newState.proposedOutcome is empty
-5. Pass: `(0, w, -) -> (0, w, -)`
-   - Covered by veto
+   - newState.proposedOutcome can be anything
+4. Veto: `(i, w, w') -> (n-1, w, -)`
+   - to veto you just propose something different
+   - newState.proposedOutcome can be anything
+5. Pass: `(n-1, w, -) -> (n-1, w, -)`
+   - pass is just a special case of veto where i = n - 1
 
 Note: either a transition is a veto, or you can switch on `furtherVotesRequired` to determine which of cases 1-3 it is.
 
@@ -48,7 +46,7 @@ linkStyle default interpolate basis
    B-->|Vote| C("proposal <br /> (n-2, w, w')")
    C-->|...| D("proposal <br /> (1, w, w')")
    D-->|FinalVote| E("consensus <br /> (0, w', -)")
-   B-->|Veto| A
-   C-->|Veto| A
-   D-->|Veto| A
+   B-->|Veto| B
+   C-->|Veto| B
+   D-->|Veto| B
 </div>


### PR DESCRIPTION
This PR changes the consensus algorithm so that propose/veto/pass all set `furtherVotesRequired` to `n - 1`. This seems to simplify the contract logic.
```
Contract Name  Method Name      Calls  Min Gas  Max Gas  Average Gas
-------------  ---------------  -----  -------  -------  -----------
ConsensusApp   validTransition  11     31929    34017    33041   // master
ConsensusApp2  validTransition  11     31513    33945    32602   // tc-alternative-consensus-game
ConsensusApp3  validTransition  8      31585    33963    32497   // this branch
```
