### PR TITLE
Increase readability of transferAll test

### DIFF
--- a/test/AssetHolder/transferAll.test.ts
+++ b/test/AssetHolder/transferAll.test.ts
@@ -71,9 +71,10 @@ describe('transferAll', () => {
       payouts = replaceAddresses(payouts, addresses);
 
       // reset the holdings (only works on test contract)
-      Object.keys(heldBefore).forEach(async key => {
-        await (await AssetHolder.setHoldings(key, heldBefore[key])).wait();
-        expect((await AssetHolder.holdings(key)).eq(heldBefore[key])).toBe(true);
+      Object.keys(heldAfter).forEach(async key => {
+        const amount = heldBefore[key] ? heldBefore[key] : 0;
+        await (await AssetHolder.setHoldings(key, amount)).wait();
+        expect((await AssetHolder.holdings(key)).eq(amount)).toBe(true);
       });
 
       // compute an appropriate allocation.

--- a/test/AssetHolder/transferAll.test.ts
+++ b/test/AssetHolder/transferAll.test.ts
@@ -34,25 +34,25 @@ beforeAll(async () => {
   AssetHolder = await setupContracts(provider, AssetHolderArtifact);
 });
 
-const reason = 'transferAll | submitted data does not match stored outcomeHash';
+const reason0 = 'transferAll | submitted data does not match stored outcomeHash';
 
 // c is the channel we are transferring from.
 describe('transferAll', () => {
   it.each`
-    name                              | heldBefore            | setOutcome      | newOutcome | heldAfter             | payouts         | reason
-    ${' 0. outcome not set         '} | ${{c: 1}}             | ${{}}           | ${{}}      | ${{}}                 | ${{A: 1}}       | ${reason}
-    ${' 1. funded          -> 1 EOA'} | ${{c: 1}}             | ${{A: 1}}       | ${{}}      | ${{}}                 | ${{A: 1}}       | ${undefined}
-    ${' 2. overfunded      -> 1 EOA'} | ${{c: 2}}             | ${{A: 1}}       | ${{}}      | ${{c: 1}}             | ${{A: 1}}       | ${undefined}
-    ${' 3. underfunded     -> 1 EOA'} | ${{c: 1}}             | ${{A: 2}}       | ${{A: 1}}  | ${{}}                 | ${{A: 1}}       | ${undefined}
-    ${' 4. funded      -> 1 channel'} | ${{c: 1, C: 0}}       | ${{C: 1}}       | ${{}}      | ${{c: 0, C: 1}}       | ${{}}           | ${undefined}
-    ${' 5. overfunded  -> 1 channel'} | ${{c: 2, C: 0}}       | ${{C: 1}}       | ${{}}      | ${{c: 1, C: 1}}       | ${{}}           | ${undefined}
-    ${' 6. underfunded -> 1 channel'} | ${{c: 1, C: 0}}       | ${{C: 2}}       | ${{C: 1}}  | ${{c: 0, C: 1}}       | ${{}}           | ${undefined}
-    ${' 7. -> 2 EOA       full/full'} | ${{c: 2}}             | ${{A: 1, B: 1}} | ${{}}      | ${{c: 0}}             | ${{A: 1, B: 1}} | ${undefined}
-    ${' 8. -> 2 EOA         full/no'} | ${{c: 1}}             | ${{A: 1, B: 1}} | ${{B: 1}}  | ${{c: 0}}             | ${{A: 1}}       | ${undefined}
-    ${' 9. -> 2 EOA    full/partial'} | ${{c: 3}}             | ${{A: 2, B: 2}} | ${{B: 1}}  | ${{c: 0}}             | ${{A: 2, B: 1}} | ${undefined}
-    ${'10. -> 2 chan      full/full'} | ${{c: 2, C: 0, X: 0}} | ${{C: 1, X: 1}} | ${{}}      | ${{c: 0, C: 1, X: 1}} | ${{}}           | ${undefined}
-    ${'11. -> 2 chan        full/no'} | ${{c: 1, C: 0, X: 0}} | ${{C: 1, X: 1}} | ${{X: 1}}  | ${{c: 0, C: 1, X: 0}} | ${{}}           | ${undefined}
-    ${'12. -> 2 chan   full/partial'} | ${{c: 3, C: 0, X: 0}} | ${{C: 2, X: 2}} | ${{X: 1}}  | ${{c: 0, C: 2, X: 1}} | ${{}}           | ${undefined}
+    name                              | heldBefore | setOutcome      | newOutcome | heldAfter             | payouts         | reason
+    ${' 0. outcome not set         '} | ${{c: 1}}  | ${{}}           | ${{}}      | ${{}}                 | ${{A: 1}}       | ${reason0}
+    ${' 1. funded          -> 1 EOA'} | ${{c: 1}}  | ${{A: 1}}       | ${{}}      | ${{}}                 | ${{A: 1}}       | ${undefined}
+    ${' 2. overfunded      -> 1 EOA'} | ${{c: 2}}  | ${{A: 1}}       | ${{}}      | ${{c: 1}}             | ${{A: 1}}       | ${undefined}
+    ${' 3. underfunded     -> 1 EOA'} | ${{c: 1}}  | ${{A: 2}}       | ${{A: 1}}  | ${{}}                 | ${{A: 1}}       | ${undefined}
+    ${' 4. funded      -> 1 channel'} | ${{c: 1}}  | ${{C: 1}}       | ${{}}      | ${{c: 0, C: 1}}       | ${{}}           | ${undefined}
+    ${' 5. overfunded  -> 1 channel'} | ${{c: 2}}  | ${{C: 1}}       | ${{}}      | ${{c: 1, C: 1}}       | ${{}}           | ${undefined}
+    ${' 6. underfunded -> 1 channel'} | ${{c: 1}}  | ${{C: 2}}       | ${{C: 1}}  | ${{c: 0, C: 1}}       | ${{}}           | ${undefined}
+    ${' 7. -> 2 EOA       full/full'} | ${{c: 2}}  | ${{A: 1, B: 1}} | ${{}}      | ${{c: 0}}             | ${{A: 1, B: 1}} | ${undefined}
+    ${' 8. -> 2 EOA         full/no'} | ${{c: 1}}  | ${{A: 1, B: 1}} | ${{B: 1}}  | ${{c: 0}}             | ${{A: 1}}       | ${undefined}
+    ${' 9. -> 2 EOA    full/partial'} | ${{c: 3}}  | ${{A: 2, B: 2}} | ${{B: 1}}  | ${{c: 0}}             | ${{A: 2, B: 1}} | ${undefined}
+    ${'10. -> 2 chan      full/full'} | ${{c: 2}}  | ${{C: 1, X: 1}} | ${{}}      | ${{c: 0, C: 1, X: 1}} | ${{}}           | ${undefined}
+    ${'11. -> 2 chan        full/no'} | ${{c: 1}}  | ${{C: 1, X: 1}} | ${{X: 1}}  | ${{c: 0, C: 1, X: 0}} | ${{}}           | ${undefined}
+    ${'12. -> 2 chan   full/partial'} | ${{c: 3}}  | ${{C: 2, X: 2}} | ${{X: 1}}  | ${{c: 0, C: 2, X: 1}} | ${{}}           | ${undefined}
   `(
     `$name: heldBefore: $heldBefore, setOutcome: $setOutcome, newOutcome: $newOutcome, heldAfter: $heldAfter, payouts: $payouts`,
     async ({name, heldBefore, setOutcome, newOutcome, heldAfter, payouts, reason}) => {
@@ -71,8 +71,9 @@ describe('transferAll', () => {
       payouts = replaceAddresses(payouts, addresses);
 
       // reset the holdings (only works on test contract)
-      Object.keys(heldAfter).forEach(async key => {
-        const amount = heldBefore[key] ? heldBefore[key] : 0;
+      new Set([...Object.keys(heldAfter), ...Object.keys(heldBefore)]).forEach(async key => {
+        // key must be either in heldBefore or heldAfter or both
+        const amount = heldBefore[key] ? heldBefore[key] : bigNumberify(0);
         await (await AssetHolder.setHoldings(key, amount)).wait();
         expect((await AssetHolder.holdings(key)).eq(amount)).toBe(true);
       });

--- a/test/AssetHolder/transferAll.test.ts
+++ b/test/AssetHolder/transferAll.test.ts
@@ -8,13 +8,12 @@ import {
   randomChannelId,
   allocationToParams,
   sendTransaction,
+  transformInputData,
 } from '../test-helpers';
 import {HashZero} from 'ethers/constants';
 import {createTransferAllTransaction} from '../../src/transaction-creators/asset-holder';
-
 const AssetHolderInterface = new ethers.utils.Interface(AssetHolderArtifact.abi);
-import {keccak256} from 'ethers/utils/solidity';
-import {id, toUtf8Bytes, bigNumberify} from 'ethers/utils';
+import {id, bigNumberify} from 'ethers/utils';
 
 const provider = new ethers.providers.JsonRpcProvider(
   `http://localhost:${process.env.DEV_GANACHE_PORT}`,
@@ -22,13 +21,15 @@ const provider = new ethers.providers.JsonRpcProvider(
 
 let AssetHolder: ethers.Contract;
 
-// channels
-const C = randomChannelId();
-const X = randomChannelId();
-
-// externals
-const A = ethers.Wallet.createRandom().address.padEnd(66, '0');
-const B = ethers.Wallet.createRandom().address.padEnd(66, '0');
+const addresses = {
+  // channels
+  c: undefined,
+  C: randomChannelId(),
+  X: randomChannelId(),
+  // externals
+  A: ethers.Wallet.createRandom().address.padEnd(66, '0'),
+  B: ethers.Wallet.createRandom().address.padEnd(66, '0'),
+};
 
 beforeAll(async () => {
   AssetHolder = await setupContracts(provider, AssetHolderArtifact);
@@ -61,98 +62,85 @@ const description11 =
 const description12 =
   '12. Transfers all holdings from directly-funded channel allocating to two channels (full payout, partial payout)';
 
+// ${description1}  | ${true}    | ${1} | ${[A]}     | ${['1']}      | ${[]}     | ${[]}        | ${[]}       | ${[]}            | ${[]}         | ${'0'}    | ${undefined}
+// ${description2}  | ${true}    | ${2} | ${[A]}     | ${['1']}      | ${[]}     | ${[]}        | ${[]}       | ${[]}            | ${['1']}      | ${'1'}    | ${undefined}
+// ${description3}  | ${true}    | ${1} | ${[A]}     | ${['2']}      | ${[A]}    | ${['1']}     | ${[]}       | ${[]}            | ${['1']}      | ${'0'}    | ${undefined}
+// ${description4}  | ${true}    | ${1} | ${[C]}     | ${['1']}      | ${[]}     | ${[]}        | ${[C]}      | ${['1']}         | ${[]}         | ${'0'}    | ${undefined}
+// ${description5}  | ${true}    | ${2} | ${[C]}     | ${['1']}      | ${[]}     | ${[]}        | ${[C]}      | ${['1']}         | ${[]}         | ${'1'}    | ${undefined}
+// ${description6}  | ${true}    | ${1} | ${[C]}     | ${['2']}      | ${[C]}    | ${['1']}     | ${[C]}      | ${['1']}         | ${[]}         | ${'0'}    | ${undefined}
+// ${description7}  | ${true}    | ${2} | ${[A, B]}  | ${['1', '1']} | ${[]}     | ${[]}        | ${[]}       | ${[]}            | ${['1', '1']} | ${'0'}    | ${undefined}
+// ${description8}  | ${true}    | ${1} | ${[A, B]}  | ${['1', '1']} | ${[B]}    | ${['1']}     | ${[]}       | ${[]}            | ${['1']}      | ${'0'}    | ${undefined}
+// ${description9}  | ${true}    | ${3} | ${[A, B]}  | ${['2', '2']} | ${[B]}    | ${['1']}     | ${[]}       | ${[]}            | ${['2', '1']} | ${'0'}    | ${undefined}
+// ${description10} | ${true}    | ${2} | ${[C, X]}  | ${['1', '1']} | ${[]}     | ${[]}        | ${[C, X]}   | ${['1', '1']}    | ${[]}         | ${'0'}    | ${undefined}
+// ${description11} | ${true}    | ${1} | ${[C, X]}  | ${['1', '1']} | ${[X]}    | ${['1']}     | ${[C]}      | ${['1']}         | ${[]}         | ${'0'}    | ${undefined}
+// ${description12} | ${true}    | ${3} | ${[C, X]}  | ${['2', '2']} | ${[X]}    | ${['1']}     | ${[C, X]}   | ${['2', '1']}    | ${[]}         | ${'0'}    | ${undefined}
+
 // amounts are valueString represenationa of wei
+// c is the channel we are transferring from. TODO work out how to track it below
 describe('transferAll', () => {
   it.each`
-    description      | outcomeSet | held   | destBefore | amountsBefore | destAfter | amountsAfter | heldAfterId | heldAfterAmounts | payouts       | heldAfter | reasonString
-    ${description0}  | ${false}   | ${'1'} | ${[A]}     | ${['1']}      | ${[]}     | ${[]}        | ${[]}       | ${[]}            | ${[]}         | ${'0'}    | ${reason1}
-    ${description1}  | ${true}    | ${'1'} | ${[A]}     | ${['1']}      | ${[]}     | ${[]}        | ${[]}       | ${[]}            | ${[]}         | ${'0'}    | ${undefined}
-    ${description2}  | ${true}    | ${'2'} | ${[A]}     | ${['1']}      | ${[]}     | ${[]}        | ${[]}       | ${[]}            | ${['1']}      | ${'1'}    | ${undefined}
-    ${description3}  | ${true}    | ${'1'} | ${[A]}     | ${['2']}      | ${[A]}    | ${['1']}     | ${[]}       | ${[]}            | ${['1']}      | ${'0'}    | ${undefined}
-    ${description4}  | ${true}    | ${'1'} | ${[C]}     | ${['1']}      | ${[]}     | ${[]}        | ${[C]}      | ${['1']}         | ${[]}         | ${'0'}    | ${undefined}
-    ${description5}  | ${true}    | ${'2'} | ${[C]}     | ${['1']}      | ${[]}     | ${[]}        | ${[C]}      | ${['1']}         | ${[]}         | ${'1'}    | ${undefined}
-    ${description6}  | ${true}    | ${'1'} | ${[C]}     | ${['2']}      | ${[C]}    | ${['1']}     | ${[C]}      | ${['1']}         | ${[]}         | ${'0'}    | ${undefined}
-    ${description7}  | ${true}    | ${'2'} | ${[A, B]}  | ${['1', '1']} | ${[]}     | ${[]}        | ${[]}       | ${[]}            | ${['1', '1']} | ${'0'}    | ${undefined}
-    ${description8}  | ${true}    | ${'1'} | ${[A, B]}  | ${['1', '1']} | ${[B]}    | ${['1']}     | ${[]}       | ${[]}            | ${['1']}      | ${'0'}    | ${undefined}
-    ${description9}  | ${true}    | ${'3'} | ${[A, B]}  | ${['2', '2']} | ${[B]}    | ${['1']}     | ${[]}       | ${[]}            | ${['2', '1']} | ${'0'}    | ${undefined}
-    ${description10} | ${true}    | ${'2'} | ${[C, X]}  | ${['1', '1']} | ${[]}     | ${[]}        | ${[C, X]}   | ${['1', '1']}    | ${[]}         | ${'0'}    | ${undefined}
-    ${description11} | ${true}    | ${'1'} | ${[C, X]}  | ${['1', '1']} | ${[X]}    | ${['1']}     | ${[C]}      | ${['1']}         | ${[]}         | ${'0'}    | ${undefined}
-    ${description12} | ${true}    | ${'3'} | ${[C, X]}  | ${['2', '2']} | ${[X]}    | ${['1']}     | ${[C, X]}   | ${['2', '1']}    | ${[]}         | ${'0'}    | ${undefined}
+    name                                  | heldBefore | setOutcome | newOutcome | heldAfter | payouts   | reason
+    ${'1. Finalized, funded, single EOA'} | ${{c: 1}}  | ${{A: 1}}  | ${{}}      | ${{}}     | ${{A: 1}} | ${undefined}
   `(
-    '$description',
-    async ({
-      description,
-      outcomeSet,
-      held,
-      destBefore,
-      amountsBefore,
-      destAfter,
-      amountsAfter,
-      heldAfterId,
-      heldAfterAmounts,
-      payouts,
-      heldAfter,
-      reasonString,
-    }) => {
-      amountsBefore = amountsBefore.map(x => ethers.utils.parseUnits(x, 'wei'));
-      amountsAfter = amountsAfter.map(x => ethers.utils.parseUnits(x, 'wei'));
-      heldAfterAmounts = heldAfterAmounts.map(x => ethers.utils.parseUnits(x, 'wei'));
-      held = ethers.utils.parseUnits(held, 'wei');
-      heldAfter = ethers.utils.parseUnits(heldAfter, 'wei');
-      if (payouts.length > 0) {
-        payouts = payouts.map(x => ethers.utils.parseUnits(x, 'wei'));
-      }
-
+    `$name: heldBefore: $heldBefore, setOutcome: $setOutcome, newOutcome: $newOutcome, heldAfter: $heldAfter, payouts: $payouts`,
+    async ({name, heldBefore, setOutcome, newOutcome, heldAfter, payouts, reason}) => {
       // compute channelId
-      const nonce = bigNumberify(id(description))
+      const nonce = bigNumberify(id(name))
         .maskn(30)
         .toNumber();
       const channelId = randomChannelId(nonce);
+      addresses.c = channelId;
 
-      // set holdings (only works on test contract)
-      if (held > 0) {
-        await (await AssetHolder.setHoldings(channelId, held)).wait();
-        expect(await AssetHolder.holdings(channelId)).toEqual(held);
+      // prepare input data
+      setOutcome = transformInputData(setOutcome, addresses);
+      heldBefore = transformInputData(heldBefore, addresses);
+      heldAfter = transformInputData(heldAfter, addresses);
+      payouts = transformInputData(payouts, addresses);
+
+      // reset the holdings for any beneficiary channels we expect to be updated
+      Object.keys(heldAfter).forEach(async key => {
+        await (await AssetHolder.setHoldings(key, 0)).wait();
+        expect((await AssetHolder.holdings(key)).eq(0)).toBe(true);
+      });
+
+      // set holdings for channelId (only works on test contract)
+      if (heldBefore[channelId] > 0) {
+        await (await AssetHolder.setHoldings(channelId, heldBefore[channelId])).wait();
+        expect(await AssetHolder.holdings(channelId)).toEqual(heldBefore[channelId]);
       }
 
-      // also reset the holdings for any beneficiary contracts we expect to be updated
-      if (heldAfterId.length > 0) {
-        heldAfterId.forEach(async (x, index) => {
-          await (await AssetHolder.setHoldings(x, 0)).wait();
-          expect((await AssetHolder.holdings(x)).eq(0)).toBe(true);
-        });
-      }
-
-      // compute an appropriate allocation
-      const allocation = destBefore.map((x, index, array) => ({
-        destination: x,
-        amount: amountsBefore[index],
-      }));
-      const [allocationBytes, outcomeHash] = allocationToParams(allocation);
+      // compute an appropriate allocation.
+      const allocation = [];
+      Object.keys(setOutcome).forEach(key =>
+        allocation.push({destination: key, amount: setOutcome[key]}),
+      );
+      const [_, outcomeHash] = allocationToParams(allocation);
 
       // set outcomeHash
-      if (outcomeSet) {
-        await (await AssetHolder.setOutcomePermissionless(channelId, outcomeHash)).wait();
-        expect(await AssetHolder.outcomeHashes(channelId)).toBe(outcomeHash);
-      }
+      await (await AssetHolder.setOutcomePermissionless(channelId, outcomeHash)).wait();
+      expect(await AssetHolder.outcomeHashes(channelId)).toBe(outcomeHash);
+
       const transactionRequest = createTransferAllTransaction(
         AssetHolderInterface,
         channelId,
         allocation,
       );
+
       // call method in a slightly different way if expecting a revert
-      if (reasonString) {
+      if (reason) {
         const regex = new RegExp(
-          '^' + 'VM Exception while processing transaction: revert ' + reasonString + '$',
+          '^' + 'VM Exception while processing transaction: revert ' + reason + '$',
         );
-        await expectRevert(() =>
-          sendTransaction(provider, AssetHolder.address, transactionRequest),
+        await expectRevert(
+          () => sendTransaction(provider, AssetHolder.address, transactionRequest),
+          regex,
         );
       } else {
         // register for events
-        const assetTransferredEvents = destBefore.map((x, index, array) => {
-          if (payouts[index] && payouts[index].gt(0)) {
-            return newAssetTransferredEvent(AssetHolder, x);
+        const assetTransferredEvents = [];
+        Object.keys(payouts).forEach(key => {
+          if (payouts[key].gt(0)) {
+            assetTransferredEvents.push(newAssetTransferredEvent(AssetHolder, key));
           }
         });
 
@@ -167,29 +155,23 @@ describe('transferAll', () => {
         });
 
         // check new holdings
-        expect(await AssetHolder.holdings(channelId)).toEqual(heldAfter);
-        if (heldAfterId.length > 0) {
-          heldAfterId.forEach(async (x, index, array) => {
-            expect(await AssetHolder.holdings(x)).toEqual(heldAfterAmounts[index]);
-          });
-        }
+        Object.keys(heldAfter).forEach(async key =>
+          expect(await AssetHolder.holdings(key).toEqual(heldAfter[key])),
+        );
 
         // check new outcomeHash
         let expectedNewOutcomeHash;
-        let _;
+        let __;
 
-        if (destAfter.length > 0) {
-          // compute an appropriate allocation
-          const allocationAfter = destAfter.map((x, index, array) => ({
-            destination: x,
-            amount: amountsAfter[index],
-          }));
-
-          [_, expectedNewOutcomeHash] = allocationToParams(allocationAfter);
+        const allocationAfter = [];
+        Object.keys(newOutcome).forEach(key => {
+          allocationAfter.push({destination: key, amount: newOutcome[key]});
+        });
+        if (allocationAfter.length > 0) {
+          [__, expectedNewOutcomeHash] = allocationToParams(allocationAfter);
         } else {
           expectedNewOutcomeHash = HashZero;
         }
-
         expect(await AssetHolder.outcomeHashes(channelId)).toEqual(expectedNewOutcomeHash);
       }
     },

--- a/test/AssetHolder/transferAll.test.ts
+++ b/test/AssetHolder/transferAll.test.ts
@@ -8,7 +8,7 @@ import {
   randomChannelId,
   allocationToParams,
   sendTransaction,
-  transformInputData,
+  replaceAddresses,
 } from '../test-helpers';
 import {createTransferAllTransaction} from '../../src/transaction-creators/asset-holder';
 const AssetHolderInterface = new ethers.utils.Interface(AssetHolderArtifact.abi);
@@ -64,11 +64,11 @@ describe('transferAll', () => {
       addresses.c = channelId;
 
       // transform input data (unpack addresses and BigNumberify amounts)
-      heldBefore = transformInputData(heldBefore, addresses);
-      setOutcome = transformInputData(setOutcome, addresses);
-      newOutcome = transformInputData(newOutcome, addresses);
-      heldAfter = transformInputData(heldAfter, addresses);
-      payouts = transformInputData(payouts, addresses);
+      heldBefore = replaceAddresses(heldBefore, addresses);
+      setOutcome = replaceAddresses(setOutcome, addresses);
+      newOutcome = replaceAddresses(newOutcome, addresses);
+      heldAfter = replaceAddresses(heldAfter, addresses);
+      payouts = replaceAddresses(payouts, addresses);
 
       // reset the holdings (only works on test contract)
       Object.keys(heldBefore).forEach(async key => {

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -201,3 +201,11 @@ export async function signStates(
   const promises = wallets.map(async (w, i) => await sign(w, stateHashes[whoSignedWhat[i]]));
   return Promise.all(promises);
 }
+
+export function transformInputData(object, addresses) {
+  const newObject = {};
+  Object.keys(object).forEach(key => {
+    newObject[addresses[key]] = bigNumberify(object[key]);
+  });
+  return newObject;
+}

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -205,7 +205,7 @@ export async function signStates(
   return Promise.all(promises);
 }
 
-export function transformInputData(object, addresses) {
+export function replaceAddresses(object, addresses) {
   const newObject = {};
   Object.keys(object).forEach(key => {
     newObject[addresses[key]] = bigNumberify(object[key]);

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -7,8 +7,7 @@ import {
   bigNumberify,
   Signature,
 } from 'ethers/utils';
-import {AddressZero} from 'ethers/constants';
-
+import {AddressZero, HashZero} from 'ethers/constants';
 import {hashChannelStorage} from '../src/channel-storage';
 import {
   Outcome,
@@ -180,8 +179,12 @@ export async function sendTransaction(
 
 export function allocationToParams(allocation: Allocation) {
   const allocationBytes = encodeAllocation(allocation);
-
-  const outcomeContentHash = hashOutcomeContent(allocation);
+  let outcomeContentHash;
+  if (allocation.length == 0) {
+    outcomeContentHash = HashZero;
+  } else {
+    outcomeContentHash = hashOutcomeContent(allocation);
+  }
   return [allocationBytes, outcomeContentHash];
 }
 


### PR DESCRIPTION
This PR aims to make the most of jest's `it.each` method. Specifically, it aims to make the information expressed in the table of test cases as dense and as readable as possible, (at the expense of possibly having to work harder to transform that information into the required format for the test itself).

- test names include a terse string literal place directly in the table, as well as unpacked test data
- an `addresses` lookup allows shorthand such as `{A:1}` to be used in the table (instead of `{
0x4128756.... : 1}`

![Screenshot 2019-09-11 at 13 38 50](https://user-images.githubusercontent.com/1833419/64697791-83eddf00-d499-11e9-9a37-445a8edeaad7.png)
became 
![Screenshot 2019-09-11 at 13 39 38](https://user-images.githubusercontent.com/1833419/64697835-9ec05380-d499-11e9-979b-ed19996c00a8.png)

If agreeable, we could role something similar out to other tests (particularly `claimAll.test.ts`). 
