### PR TITLE
Comment out unused parameters

### DIFF
--- a/contracts/ConsensusApp.sol
+++ b/contracts/ConsensusApp.sol
@@ -16,7 +16,7 @@ contract ConsensusApp is ForceMoveApp {
     function validTransition(
         VariablePart memory a,
         VariablePart memory b,
-        uint256 turnNumB, // unused
+        uint256, // turnNumB
         uint256 numParticipants
     ) public pure returns (bool) {
         ConsensusAppData memory appDataA = appData(a.appData);

--- a/contracts/CountingApp.sol
+++ b/contracts/CountingApp.sol
@@ -15,8 +15,8 @@ contract CountingApp is ForceMoveApp {
     function validTransition(
         VariablePart memory a,
         VariablePart memory b,
-        uint256 turnNumB,
-        uint256 nParticipants
+        uint256, // turnNumB
+        uint256 // nParticipants
     ) public pure returns (bool) {
         require(
             appData(b.appData).counter == appData(a.appData).counter + 1,

--- a/contracts/TrivialApp.sol
+++ b/contracts/TrivialApp.sol
@@ -5,10 +5,10 @@ import './ForceMoveApp.sol';
 
 contract TrivialApp is ForceMoveApp {
     function validTransition(
-        VariablePart memory a,
-        VariablePart memory b,
-        uint256 turnNumB,
-        uint256 nParticipants
+        VariablePart memory, // a
+        VariablePart memory, // b
+        uint256, // turnNumB
+        uint256 // nParticipants
     ) public pure returns (bool) {
         return true;
     }


### PR DESCRIPTION
The goal is to clean up as many solidity compiler warnings as possible so that we don't miss warnings that point to issues with code logic.