### PR TITLE
Change guaranteedChannelId to targetChannelId

### DIFF
--- a/contracts/AssetHolder.sol
+++ b/contracts/AssetHolder.sol
@@ -112,14 +112,14 @@ contract AssetHolder {
     }
 
     function claimAll(
-        bytes32 channelId,
+        bytes32 guarantorChannelId,
         bytes calldata guaranteeBytes,
         bytes calldata allocationBytes
     ) external {
         // requirements
 
         require(
-            outcomeHashes[channelId] ==
+            outcomeHashes[guarantorChannelId] ==
                 keccak256(
                     abi.encode(
                         Outcome.LabelledAllocationOrGuarantee(
@@ -128,13 +128,13 @@ contract AssetHolder {
                         )
                     )
                 ),
-            'claimAll | submitted data does not match outcomeHash stored against channelId'
+            'claimAll | submitted data does not match outcomeHash stored against guarantorChannellId'
         );
 
         Outcome.Guarantee memory guarantee = abi.decode(guaranteeBytes, (Outcome.Guarantee));
 
         require(
-            outcomeHashes[guarantee.guaranteedChannelId] ==
+            outcomeHashes[guarantee.targetChannelId] ==
                 keccak256(
                     abi.encode(
                         Outcome.LabelledAllocationOrGuarantee(
@@ -143,10 +143,10 @@ contract AssetHolder {
                         )
                     )
                 ),
-            'claimAll | submitted data does not match outcomeHash stored against guaranteedChannelId'
+            'claimAll | submitted data does not match outcomeHash stored against targetChannelId'
         );
 
-        uint256 balance = holdings[channelId];
+        uint256 balance = holdings[guarantorChannelId];
 
         Outcome.AllocationItem[] memory allocation = abi.decode(
             allocationBytes,
@@ -208,7 +208,7 @@ contract AssetHolder {
         }
 
         // effects
-        holdings[channelId] = balance;
+        holdings[guarantorChannelId] = balance;
 
         // at this point have payouts array of uint256s, each corresponding to original destinations
         // and allocations has some zero amounts which we want to prune
@@ -238,7 +238,7 @@ contract AssetHolder {
 
         if (newAllocationLength > 0) {
             // store hash
-            outcomeHashes[guarantee.guaranteedChannelId] = keccak256(
+            outcomeHashes[guarantee.targetChannelId] = keccak256(
                 abi.encode(
                     Outcome.LabelledAllocationOrGuarantee(
                         uint8(Outcome.OutcomeType.Allocation),
@@ -247,7 +247,7 @@ contract AssetHolder {
                 )
             );
         } else {
-            delete outcomeHashes[guarantee.guaranteedChannelId];
+            delete outcomeHashes[guarantee.targetChannelId];
         }
 
     }

--- a/contracts/Outcome.sol
+++ b/contracts/Outcome.sol
@@ -30,7 +30,7 @@ library Outcome {
     }
 
     struct Guarantee {
-        bytes32 guaranteedChannelId;
+        bytes32 targetChannelId;
         bytes32[] destinations;
     }
 

--- a/docs/nitro/claim.md
+++ b/docs/nitro/claim.md
@@ -5,14 +5,14 @@ title: Claim
 
 ### ClaimAll
 
-- First pays out according to the allocation of the `guaranteedAddress` but with priorities set by the guarantee.
+- First pays out according to the allocation of the `targetChannelId` but with priorities set by the guarantee.
 - Pays any remaining funds out according to the default priorities.
 
-`claimAll(bytes32 channelAddress, bytes32 guaranteedAddress, bytes32[] destinations, AllocationItem[] allocation)`
+`claimAll(bytes32 guarantorChannelId, bytes32 targetChannelId, bytes32[] destinations, AllocationItem[] allocation)`
 
-- checks that `outcomes[channelAddress]` is equal to `hash(1, (guaranteedAddress, destinations))`, where `1` signifies an outcome of type `GUARANTEE`
-- checks that `outcomes[guaranteedAddress]` is equal to `hash(0, allocation)`
-- `let balance = balances[channelAddress]`
+- checks that `outcomes[guarantorChannelId]` is equal to `hash(1, (targetChannelId, destinations))`, where `1` signifies an outcome of type `GUARANTEE`
+- checks that `outcomes[targetChannelId]` is equal to `hash(0, allocation)`
+- `let balance = balances[guarantorChannelId]`
 - k = 0
 - let payouts = []
 - for 0 <= i < destinations.length
@@ -51,9 +51,9 @@ title: Claim
     - payouts[k] = (destination, amount)
     - k++
     - balance -= amount
-- sets `balances[channelAddress] = balance`
+- sets `balances[guarantorChannelId] = balance`
   - note: must do this before calling any external contracts to prevent re-entrancy bugs
-- sets `outcomes[channelAddress] = hash(newAllocation)` or clears if `newAllocation = []`
+- sets `outcomes[guarantorChannelId] = hash(newAllocation)` or clears if `newAllocation = []`
 - for each payout
   - if payout is an external address
     - do an external transfer to the address

--- a/docs/nitro/outcomes.md
+++ b/docs/nitro/outcomes.md
@@ -43,7 +43,7 @@ One adjudicator pushing to multiple asset holders.
 | AllocationOrGuarantee | `(uint8, bytes)`       | `(type, data)`, where `type` is 0 for allocations and 1 for guarantees, and `data` field is the abi-encoded form of the Allocation or Guarantee               |
 | Allocation            | `(bytes32, uint256)[]` | An list of AllocationItems, in payout priority order (highest priority first)                                                                                 |
 | AllocationItem        | `(bytes32, uint256)`   | `(destination, amount)`                                                                                                                                       |
-| Guarantee             | `(bytes32, bytes32[])` | `(guaranteedChannelAddress, destinations)`                                                                                                                    |
+| Guarantee             | `(bytes32, bytes32[])` | `(targetChannelId, destinations)`                                                                                                                             |
 | ChannelAddress        | `bytes32`              | Equal to the ChannelId defined in ForceMove                                                                                                                   |
 | ExternalAddress       | `bytes32`              | An Ethereum address right padded with 12 bytes of zeros                                                                                                       |
 | Destination           | `bytes32`              | Taken to be an ExternalAddress if starts with 12 bytes of leading zeros and a ChannelAddress otherwise                                                        |

--- a/src/outcome.ts
+++ b/src/outcome.ts
@@ -8,14 +8,14 @@ export enum OutcomeType {
 
 // Guarantee and functions
 export interface Guarantee {
-  guaranteedChannelAddress: Bytes32;
+  targetChannelId: Bytes32;
   destinations: Bytes32[];
 }
 
 export function encodeGuarantee(guarantee: Guarantee): Bytes32 {
   return defaultAbiCoder.encode(
-    ['tuple(bytes32 guaranteedChannelId, bytes32[] destinations)'],
-    [[guarantee.guaranteedChannelAddress, guarantee.destinations]],
+    ['tuple(bytes32 targetChannelId, bytes32[] destinations)'],
+    [[guarantee.targetChannelId, guarantee.destinations]],
   );
 }
 export function isGuarantee(

--- a/test/AssetHolder/claimAll.test.ts
+++ b/test/AssetHolder/claimAll.test.ts
@@ -63,8 +63,8 @@ describe('claimAll', () => {
       name,
       heldBefore,
       guaranteeDestinations,
-      cOutcomeBefore,
-      cOutcomeAfter,
+      tOutcomeBefore,
+      tOutcomeAfter,
       heldAfter,
       payouts,
       reason,
@@ -83,8 +83,8 @@ describe('claimAll', () => {
 
       // transform input data (unpack addresses and BigNumberify amounts)
       heldBefore = replaceAddresses(heldBefore, addresses);
-      cOutcomeBefore = replaceAddresses(cOutcomeBefore, addresses);
-      cOutcomeAfter = replaceAddresses(cOutcomeAfter, addresses);
+      tOutcomeBefore = replaceAddresses(tOutcomeBefore, addresses);
+      tOutcomeAfter = replaceAddresses(tOutcomeAfter, addresses);
       heldAfter = replaceAddresses(heldAfter, addresses);
       payouts = replaceAddresses(payouts, addresses);
       guaranteeDestinations = guaranteeDestinations.map(x => addresses[x]);
@@ -99,8 +99,8 @@ describe('claimAll', () => {
 
       // compute an appropriate allocation.
       const allocation = [];
-      Object.keys(cOutcomeBefore).forEach(key =>
-        allocation.push({destination: key, amount: cOutcomeBefore[key]}),
+      Object.keys(tOutcomeBefore).forEach(key =>
+        allocation.push({destination: key, amount: tOutcomeBefore[key]}),
       );
       const [_, outcomeHash] = allocationToParams(allocation);
 
@@ -165,8 +165,8 @@ describe('claimAll', () => {
 
         // check new outcomeHash
         const allocationAfter = [];
-        Object.keys(cOutcomeAfter).forEach(key => {
-          allocationAfter.push({destination: key, amount: cOutcomeAfter[key]});
+        Object.keys(tOutcomeAfter).forEach(key => {
+          allocationAfter.push({destination: key, amount: tOutcomeAfter[key]});
         });
         const [___, expectedNewOutcomeHash] = allocationToParams(allocationAfter);
         expect(await AssetHolder.outcomeHashes(targetId)).toEqual(expectedNewOutcomeHash);

--- a/test/AssetHolder/claimAll.test.ts
+++ b/test/AssetHolder/claimAll.test.ts
@@ -22,7 +22,7 @@ const provider = new ethers.providers.JsonRpcProvider(
 
 const addresses = {
   // channels
-  c: undefined, // target
+  t: undefined, // target
   g: undefined, // guarantor
   // externals
   I: ethers.Wallet.createRandom().address.padEnd(66, '0'),
@@ -36,8 +36,9 @@ beforeAll(async () => {
 });
 
 const reason5 =
-  'claimAll | submitted data does not match outcomeHash stored against guaranteedChannelId';
-const reason6 = 'claimAll | submitted data does not match outcomeHash stored against channelId';
+  'claimAll | submitted data does not match outcomeHash stored against targetChannelId';
+const reason6 =
+  'claimAll | submitted data does not match outcomeHash stored against guarantorChannelId';
 
 // 1. claim G1 (step 1 of figure 23 of nitro paper)
 // 2. claim G2 (step 2 of figure 23 of nitro paper)
@@ -47,7 +48,7 @@ const reason6 = 'claimAll | submitted data does not match outcomeHash stored aga
 // amounts are valueString representations of wei
 describe('claimAll', () => {
   it.each`
-    name                                               | heldBefore | guaranteeDestinations | cOutcomeBefore        | cOutcomeAfter   | heldAfter | payouts         | reason
+    name                                               | heldBefore | guaranteeDestinations | tOutcomeBefore        | tOutcomeAfter   | heldAfter | payouts         | reason
     ${'1. straight-through guarantee, 3 destinations'} | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${{A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
     ${'2. swap guarantee,             2 destinations'} | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${{A: 5}}       | ${{g: 0}} | ${{B: 5}}       | ${undefined}
     ${'3. swap guarantee,             3 destinations'} | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${{A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
@@ -69,15 +70,15 @@ describe('claimAll', () => {
       reason,
     }) => {
       // compute channelIds
-      const cNonce = bigNumberify(id(name))
+      const tNonce = bigNumberify(id(name))
         .maskn(30)
         .toNumber();
       const gNonce = bigNumberify(id(name + 'g'))
         .maskn(30)
         .toNumber();
-      const targetId = randomChannelId(cNonce);
+      const targetId = randomChannelId(tNonce);
       const guarantorId = randomChannelId(gNonce);
-      addresses.c = targetId;
+      addresses.t = targetId;
       addresses.g = guarantorId;
 
       // transform input data (unpack addresses and BigNumberify amounts)
@@ -111,7 +112,7 @@ describe('claimAll', () => {
 
       const guarantee = {
         destinations: guaranteeDestinations,
-        guaranteedChannelAddress: targetId,
+        targetChannelId: targetId,
       };
 
       if (guaranteeDestinations.length > 0) {


### PR DESCRIPTION
This should make it harder to confuse the two channelIds in use in `claimAll` and tests thereof. 

I find `guaranteed...` to be very close to `guarantor...` and therefore easily confused. 

`channelId` by itself, is ambiguous.

Therefore I propose we have a `guarantorChannel` which points to a `targetChannel`. Some of this terminology is already in use elsewhere in the codebase.