### PR TITLE
Allow Lint to fix no-unused-variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "clearLib": "rm -rf lib",
     "build": "run-s clearContracts clearLib build:truffle build:typescript",
     "prettier:check": "npx prettier --check '{contracts,src,test}/**/*.{ts,tsx,sol}'",
-    "prettier:write": "npx prettier --write '{contracts,src,test}/**/*.{ts,tsx,sol}'"
+    "prettier:write": "npx prettier --write '{contracts,src,test}/**/*.{ts,tsx,sol}'",
+    "lint:check": "tslint --project .",
+    "lint:write": "tslint --project . --fix"
   },
   "dependencies": {
     "@openzeppelin/contracts": "^2.3.0",

--- a/tslint.json
+++ b/tslint.json
@@ -23,6 +23,7 @@
       "allow-pascal-case",
       "allow-leading-underscore"
     ],
-    "semicolon": [true, "always"]
+    "semicolon": [true, "always"],
+    "no-unused-variable": true
   }
 }


### PR DESCRIPTION
Adds `no-unused-variable` to the lint config. While `no-unused-variable` is deprecated it allows us to fix them when running `tslint --fix`.
