### PR TITLE
Update entry point and include lib files

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nitro-protocol",
   "version": "0.0.1",
   "description": "A protocol for state channel networks",
-  "main": "truffle-config.js",
+  "main": "lib/src/index.js",
   "directories": {
     "test": "test"
   },

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.1",
   "description": "A protocol for state channel networks",
   "main": "lib/src/index.js",
+  "files": [
+    "lib/*"
+  ],
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
Updates the main entry point and includes the `lib` directory so `nitro-protocol` can be referenced from other packages correctly.