### PR TITLE
Checkpoint

### DIFF
--- a/contracts/ForceMove.sol
+++ b/contracts/ForceMove.sol
@@ -41,6 +41,13 @@ contract ForceMove {
         bytes32 outcomeHash;
     }
 
+    struct ChannelStorageLite {
+        uint256 finalizesAt;
+        bytes32 stateHash;
+        address challengerAddress;
+        bytes32 outcomeHash;
+    }
+
     mapping(bytes32 => bytes32) public channelStorageHashes;
 
     // Public methods:
@@ -334,13 +341,6 @@ contract ForceMove {
 
         // effects
         _clearChallenge(channelId, turnNumRecord);
-    }
-
-    struct ChannelStorageLite {
-        uint256 finalizesAt;
-        bytes32 stateHash;
-        address challengerAddress;
-        bytes32 outcomeHash;
     }
 
     function checkpoint(

--- a/contracts/ForceMove.sol
+++ b/contracts/ForceMove.sol
@@ -109,7 +109,7 @@ contract ForceMove {
 
         // check that the forceMove is signed by a participant and store their address
 
-        address challenger = _recoverSigner(
+        address challenger = _recoverSigner( // TODO: what if someone nabs this signature off of a transaction and uses it in a front-ran tx?
             keccak256(
                 abi.encode(
                     largestTurnNum,
@@ -362,7 +362,10 @@ contract ForceMove {
 
         ChannelStorage memory channelStorage = abi.decode(channelStorageBytes, (ChannelStorage));
 
-        require(now < channelStorage.finalizesAt, 'Challenge timed out');
+        require(
+            channelStorage.finalizesAt == 0 || now < channelStorage.finalizesAt,
+            'Challenge timed out'
+        );
         require(channelStorage.turnNumRecord < largestTurnNum, 'turnNumRecord not increased');
         require(
             keccak256(channelStorageBytes) == channelStorageHashes[channelId],

--- a/contracts/ForceMove.sol
+++ b/contracts/ForceMove.sol
@@ -78,7 +78,7 @@ contract ForceMove {
         //   - the channel is still open; and
         //   - the committed turnNumRecord is correct
         require(
-            channelStorageHashes[channelId] != bytes32(0) ||
+            channelStorageHashes[channelId] == bytes32(0) ||
                 keccak256(
                     abi.encode(ChannelStorage(turnNumRecord, 0, bytes32(0), address(0), bytes32(0)))
                 ) ==

--- a/contracts/ForceMove.sol
+++ b/contracts/ForceMove.sol
@@ -73,19 +73,18 @@ contract ForceMove {
         // Check that the proposed largestTurnNum is larger than or equal to the turnNumRecord that is being committed to
         require(largestTurnNum >= turnNumRecord, 'Stale challenge!');
 
-        // EITHER there is no information stored against channelId at all (OK)
-        if (channelStorageHashes[channelId] != bytes32(0)) {
-            // OR there is, in which case we must check the channel is still open and that the committed turnNumRecord is correct
-            require(
+        // EITHER there is no information stored against channelId at all
+        // OR there is, and we must check that
+        //   - the channel is still open; and
+        //   - the committed turnNumRecord is correct
+        require(
+            channelStorageHashes[channelId] != bytes32(0) ||
                 keccak256(
-                        abi.encode(
-                            ChannelStorage(turnNumRecord, 0, bytes32(0), address(0), bytes32(0))
-                        )
-                    ) ==
-                    channelStorageHashes[channelId],
-                'Channel is not open or turnNum does not match'
-            );
-        }
+                    abi.encode(ChannelStorage(turnNumRecord, 0, bytes32(0), address(0), bytes32(0)))
+                ) ==
+                channelStorageHashes[channelId],
+            'Channel is not open or turnNum does not match'
+        );
 
         bytes32[] memory stateHashes = new bytes32[](variableParts.length);
         stateHashes = _validTransitionChain(
@@ -350,7 +349,7 @@ contract ForceMove {
         uint8 isFinalCount, // how many of the states are final
         Signature[] memory sigs,
         uint8[] memory whoSignedWhat,
-        bytes memory channelStorageLiteBytes // This is to avoid a 'stack too deep' error by minimising the number of local variables
+        bytes memory channelStorageBytes // This is to avoid a 'stack too deep' error by minimising the number of local variables
     ) public {
         // Calculate channelId from fixed part
         bytes32 channelId = keccak256(
@@ -361,28 +360,12 @@ contract ForceMove {
         // REQUIREMENTS
         // ------------
 
-        ChannelStorageLite memory channelStorageLite = abi.decode(
-            channelStorageLiteBytes,
-            (ChannelStorageLite)
-        );
+        ChannelStorage memory channelStorage = abi.decode(channelStorageBytes, (ChannelStorage));
 
-        // check challenge has not timed out
-        require(now < channelStorageLite.finalizesAt, 'Response too late!');
-
-        // check that the declared finalizesAt and turnNumRecord match storage
+        require(now < channelStorage.finalizesAt, 'Challenge timed out');
+        require(channelStorage.turnNumRecord < largestTurnNum, 'turnNumRecord not increased');
         require(
-            keccak256(
-                    abi.encode(
-                        ChannelStorage(
-                            largestTurnNum - 1, // implicit check that we are only incrementing turnNumRecord by 1
-                            channelStorageLite.finalizesAt,
-                            channelStorageLite.stateHash,
-                            channelStorageLite.challengerAddress,
-                            channelStorageLite.outcomeHash
-                        )
-                    )
-                ) ==
-                channelStorageHashes[channelId],
+            keccak256(channelStorageBytes) == channelStorageHashes[channelId],
             'Challenge State does not match stored version'
         );
 

--- a/contracts/ForceMove.sol
+++ b/contracts/ForceMove.sol
@@ -343,7 +343,7 @@ contract ForceMove {
         bytes32 outcomeHash;
     }
 
-    function respondWithAlternative(
+    function checkpoint(
         FixedPart memory fixedPart,
         uint256 largestTurnNum,
         ForceMoveApp.VariablePart[] memory variableParts,

--- a/contracts/test/TESTForceMove.sol
+++ b/contracts/test/TESTForceMove.sol
@@ -43,6 +43,15 @@ contract TESTForceMove is ForceMove {
     // public setter for channelStorage
 
     function setChannelStorage(bytes32 channelId, ChannelStorage memory channelStorage) public {
+        if (channelStorage.finalizesAt == 0) {
+            require(
+                channelStorage.stateHash == bytes32(0) &&
+                    channelStorage.challengerAddress == address(0) &&
+                    channelStorage.outcomeHash == bytes32(0),
+                'Invalid open channel'
+            );
+        }
+
         channelStorageHashes[channelId] = keccak256(abi.encode(channelStorage));
     }
 

--- a/docs/adjudicator/checkpoint.md
+++ b/docs/adjudicator/checkpoint.md
@@ -1,9 +1,9 @@
 ---
-id: respond-with-alternative
-title: respondWithAlternative
+id: checkpoint
+title: checkpoint
 ---
 
-The `respondWithAlternative` method allows anyone with sufficient off-chain state to establish a new and higher `turnNumRecord` to clear an existing challenge stored against a `channelId`. 'Alternative' here means the new `turnNumRecord` may be supported by an alternative history of states which need not agree with the challenge state stored on chain.
+The `checkpoint` method allows anyone with sufficient off-chain state to establish a new and higher `turnNumRecord` to clear an existing challenge stored against a `channelId`. 'Alternative' here means the new `turnNumRecord` may be supported by an alternative history of states which need not agree with the challenge state stored on chain.
 
 The off-chain state is submitted (in an optimized format), and once relevant checks have passed, the existing challenge is cleared and the `turnNumRecord` is updated.
 
@@ -19,7 +19,7 @@ Signature:
         bytes32 outcomeHash;
     }
 
-    function respondWithAlternative(
+    function checkpoint(
         FixedPart memory fixedPart,
         uint256 largestTurnNum,
         ForceMoveApp.VariablePart[] memory variableParts,

--- a/docs/adjudicator/checkpoint.md
+++ b/docs/adjudicator/checkpoint.md
@@ -3,9 +3,9 @@ id: checkpoint
 title: checkpoint
 ---
 
-The `checkpoint` method allows anyone with sufficient off-chain state to establish a new and higher `turnNumRecord` to clear an existing challenge stored against a `channelId`. 'Alternative' here means the new `turnNumRecord` may be supported by an alternative history of states which need not agree with the challenge state stored on chain.
+The `checkpoint` method allows anyone with a supported off-chain state to establish a new and higher `turnNumRecord` and clear an existing challenge stored against a `channelId`.
 
-The off-chain state is submitted (in an optimized format), and once relevant checks have passed, the existing challenge is cleared and the `turnNumRecord` is updated.
+The off-chain state is submitted (in an optimized format), and once relevant checks have passed, the `turnNumRecord` is updated and the challenge, if exists is cleared.
 
 ## Specification
 
@@ -33,14 +33,13 @@ Signature:
 Requirements:
 
 - States form a chain of valid transitions
-- Channel is in the Challenge mode
 - Signatures are valid for the states
 - The `largestTurnNum` > `turnNumRecord`
 
 Effects:
 
-- Clears challenge,
 - Increases `turnNumRecord`.
+- Clears challenge, when exists.
 
 ---
 
@@ -50,7 +49,7 @@ Parameters:
 
 - Decode `channelStorageLiteBytes`
 - Calculate `channelId` from fixedPart
-- Check that `finalizesAt > now`
+- Check that `finalizesAt > now || finalizesAt == 0`
 - Calculate `storageHash` from `turnNumRecord`, `finalizesAt`, `challengerAddress`, `challengeStateHash`, `challengeOutcomeHash`
 - Check that `channelStorageHashes[channelId] == storageHash`
 - Let `m = variableParts.length`

--- a/docs/adjudicator/force-move.md
+++ b/docs/adjudicator/force-move.md
@@ -5,7 +5,7 @@ title: forceMove
 
 The `forceMove` function allows anyone holding the appropriate off-chain state to register a challenge on chain, and gives the framework its name. It is designed to ensure that a state channel can progress or be finalized in the event of inactivity on behalf of a participant (e.g. the current mover).
 
-The off-chain state is submitted (in an optimized format), and once relevant checks have passed, an `outcome` is registered against the `channelId`, with a finalization time set at some delay after the transaction is processed. This delay allows the challenge to be cleared by a timely and well-formed [respond](./respond), [respondWithAlternative](./respond-with-alternative) or [refute](./refute) transaction. If no such transaction is forthcoming, the challenge will time out, allowing the `outcome` registered to be finalized. A finalized outcome can then be used to extract funds from the channel.
+The off-chain state is submitted (in an optimized format), and once relevant checks have passed, an `outcome` is registered against the `channelId`, with a finalization time set at some delay after the transaction is processed. This delay allows the challenge to be cleared by a timely and well-formed [respond](./respond), [checkpoint](./checkpoint) or [refute](./refute) transaction. If no such transaction is forthcoming, the challenge will time out, allowing the `outcome` registered to be finalized. A finalized outcome can then be used to extract funds from the channel.
 
 ## Specification
 

--- a/notes/force-move-implementation.md
+++ b/notes/force-move-implementation.md
@@ -35,7 +35,7 @@ For example, as ForceMove only works if the channel is open, which implies that 
 - Response
   - Can deduce `turnNumRecord` (as the response turnNum must be exactly one more)
   - Needs to read complete `state` and `finalizesAt`
-- RespondFromAlternative
+- checkpoint
   - Can deduce `turnNumRecord`
   - Needs to read `finalizesAt`
 - Refute
@@ -65,7 +65,7 @@ From this we get the following properties that we want for the `channelStorageHa
   - Needs n distinct signatures
 - Respond
   - Needs one full state
-- RespondFromAlternative
+- checkpoint
   - Needs to be passed a sequence of n full states
 - Refute
   - Needs a proof of signature of higher state

--- a/src/contract/channel-storage.ts
+++ b/src/contract/channel-storage.ts
@@ -1,4 +1,4 @@
-import {Uint256, Bytes32, Address} from './types';
+import {Uint256, Bytes32, Address, Bytes} from './types';
 import {defaultAbiCoder, keccak256} from 'ethers/utils';
 import {Outcome, hashOutcome} from './outcome';
 import {State, hashState} from './state';
@@ -36,7 +36,18 @@ export function hashChannelStorage(channelStorage: ChannelStorage): Bytes32 {
   );
 }
 
-export function encodeChannelStorageLite(channelStorageLite: ChannelStorageLite): Bytes32 {
+export function encodeChannelStorage(channelStorage: ChannelStorage): Bytes {
+  const outcomeHash = channelStorage.outcome ? hashOutcome(channelStorage.outcome) : HashZero;
+  const stateHash = channelStorage.state ? hashState(channelStorage.state) : HashZero;
+  const {finalizesAt, challengerAddress, largestTurnNum} = channelStorage;
+
+  return defaultAbiCoder.encode(
+    [CHANNEL_STORAGE_TYPE],
+    [[largestTurnNum, finalizesAt, stateHash, challengerAddress, outcomeHash]],
+  );
+}
+
+export function encodeChannelStorageLite(channelStorageLite: ChannelStorageLite): Bytes {
   const outcomeHash = channelStorageLite.outcome
     ? hashOutcome(channelStorageLite.outcome)
     : HashZero;

--- a/src/contract/channel-storage.ts
+++ b/src/contract/channel-storage.ts
@@ -42,7 +42,6 @@ export function encodeChannelStorage({
   It is currently up to the caller to ensure this.
   */
   const isOpen = eqHex(finalizesAt, HashZero);
-  const isFinalized = !isOpen && !state;
 
   if (isOpen && (outcome || state || challengerAddress)) {
     throw new Error(
@@ -52,7 +51,7 @@ export function encodeChannelStorage({
 
   const stateHash = isOpen || !state ? HashZero : hashState(state);
   const outcomeHash = isOpen ? HashZero : hashOutcome(outcome);
-  challengerAddress = isOpen || isFinalized ? AddressZero : challengerAddress;
+  challengerAddress = challengerAddress || AddressZero;
 
   return defaultAbiCoder.encode(
     [CHANNEL_STORAGE_TYPE],

--- a/src/contract/channel-storage.ts
+++ b/src/contract/channel-storage.ts
@@ -11,6 +11,8 @@ export interface ChannelStorage {
   challengerAddress: Address;
   outcome?: Outcome;
 }
+const CHANNEL_STORAGE_TYPE =
+  'tuple(uint256 turnNumRecord, uint256 finalizesAt, bytes32 stateHash, address challengerAddress, bytes32 outcomeHash)';
 
 export interface ChannelStorageLite {
   finalizesAt: Uint256;
@@ -18,6 +20,8 @@ export interface ChannelStorageLite {
   challengerAddress: Address;
   outcome: Outcome;
 }
+const CHANNEL_STORAGE_LITE_TYPE =
+  'tuple(uint256 finalizesAt, bytes32 stateHash, address challengerAddress, bytes32 outcomeHash)';
 
 export function hashChannelStorage(channelStorage: ChannelStorage): Bytes32 {
   const outcomeHash = channelStorage.outcome ? hashOutcome(channelStorage.outcome) : HashZero;
@@ -40,9 +44,7 @@ export function encodeChannelStorageLite(channelStorageLite: ChannelStorageLite)
   const {finalizesAt, challengerAddress} = channelStorageLite;
 
   return defaultAbiCoder.encode(
-    [
-      'tuple(uint256 finalizesAt, bytes32 stateHash, address challengerAddress, bytes32 outcomeHash)',
-    ],
+    [CHANNEL_STORAGE_LITE_TYPE],
     [[finalizesAt, stateHash, challengerAddress, outcomeHash]],
   );
 }

--- a/src/contract/transaction-creators/force-move.ts
+++ b/src/contract/transaction-creators/force-move.ts
@@ -14,14 +14,22 @@ const GAS_LIMIT = 3000000;
 
 const ForceMoveContractInterface = new ethers.utils.Interface(ForceMoveArtifact.abi);
 
-export function createCheckpointTransaction(
-  challengeState: State,
-  finalizesAt: string,
-  states: State[],
-  signatures: Signature[],
-  whoSignedWhat: number[],
-  turnNumRecord: string,
-): TransactionRequest {
+interface CheckpointData {
+  challengeState: State;
+  finalizesAt: string;
+  states: State[];
+  signatures: Signature[];
+  whoSignedWhat: number[];
+  turnNumRecord: string;
+}
+export function createCheckpointTransaction({
+  challengeState,
+  finalizesAt,
+  states,
+  signatures,
+  whoSignedWhat,
+  turnNumRecord,
+}: CheckpointData): TransactionRequest {
   const largestTurnNum = Math.max(...states.map(s => s.turnNum));
   const fixedPart = getFixedPart(challengeState);
   const variableParts = states.map(s => getVariablePart(s));

--- a/src/contract/transaction-creators/force-move.ts
+++ b/src/contract/transaction-creators/force-move.ts
@@ -14,7 +14,7 @@ const GAS_LIMIT = 3000000;
 
 const ForceMoveContractInterface = new ethers.utils.Interface(ForceMoveArtifact.abi);
 
-export function createRespondWithAlternativeTransaction(
+export function createCheckpointTransaction(
   challengeState: State,
   finalizesAt: string,
   states: State[],
@@ -36,7 +36,7 @@ export function createRespondWithAlternativeTransaction(
     state: challengeState,
   });
 
-  const data = ForceMoveContractInterface.functions.respondWithAlternative.encode([
+  const data = ForceMoveContractInterface.functions.checkpoint.encode([
     fixedPart,
     largestTurnNum,
     variableParts,

--- a/src/contract/transaction-creators/force-move.ts
+++ b/src/contract/transaction-creators/force-move.ts
@@ -6,8 +6,7 @@ import {State, getVariablePart, getFixedPart, hashAppPart} from '../state';
 import {Signature} from 'ethers/utils';
 import {hashOutcome} from '../outcome';
 import {encodeChannelStorageLite, encodeChannelStorage} from '../channel-storage';
-import {AddressZero, Zero} from 'ethers/constants';
-import {eqHex} from '../../hex-utils';
+import {Zero} from 'ethers/constants';
 
 // TODO: Currently we are setting some arbitrary gas limit
 // to avoid issues with Ganache sendTransaction and parsing BN.js
@@ -32,20 +31,20 @@ export function createCheckpointTransaction({
   whoSignedWhat,
   turnNumRecord,
 }: CheckpointData): TransactionRequest {
-  const isOpen = eqHex(finalizesAt, Zero.toHexString());
+  const isOpen = Zero.eq(finalizesAt);
   if (isOpen && challengeState) {
     throw new Error('Invalid open storage');
   }
 
   const largestTurnNum = Math.max(...states.map(s => s.turnNum));
-  const fixedPart = getFixedPart(challengeState);
+  const fixedPart = getFixedPart(states[0]);
   const variableParts = states.map(s => getVariablePart(s));
   const isFinalCount = states.filter(s => s.isFinal).length;
-  const {outcome, channel} = challengeState;
-  const {participants} = channel;
+  const {participants} = states[0].channel;
 
+  const outcome = isOpen ? undefined : challengeState.outcome;
   const challengerAddress = isOpen
-    ? AddressZero
+    ? undefined
     : participants[challengeState.turnNum % participants.length];
 
   const challengeStorageBytes = encodeChannelStorage({

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -4,6 +4,7 @@ import {State} from './contract/state';
 import {Signature} from 'ethers/utils';
 import {getStateSignerAddress} from './signatures';
 import {ChannelStorage, SignedState} from '.';
+import {toHex} from './hex-utils';
 
 export function createForceMoveTransaction(
   channelStorage: ChannelStorage,
@@ -44,13 +45,14 @@ export function createCheckpointTransaction(
     throw new Error('No active challenge in challenge state');
   }
   const {states, signatures, whoSignedWhat} = createSignatureArguments(signedStates);
-  return forceMoveTrans.createCheckpointTransaction(
-    channelStorage.challengeState,
-    channelStorage.finalizesAt,
+  return forceMoveTrans.createCheckpointTransaction({
+    challengeState: channelStorage.challengeState,
+    turnNumRecord: toHex(channelStorage.turnNumRecord),
+    finalizesAt: channelStorage.finalizesAt,
     states,
     signatures,
     whoSignedWhat,
-  );
+  });
 }
 
 export function createConcludeTransaction(

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -36,7 +36,7 @@ export function createRespondTransaction(
   );
 }
 
-export function createRespondWithAlternativeTransaction(
+export function createCheckpointTransaction(
   channelStorage: ChannelStorage,
   signedStates: SignedState[],
 ): TransactionRequest {
@@ -44,7 +44,7 @@ export function createRespondWithAlternativeTransaction(
     throw new Error('No active challenge in challenge state');
   }
   const {states, signatures, whoSignedWhat} = createSignatureArguments(signedStates);
-  return forceMoveTrans.createRespondWithAlternativeTransaction(
+  return forceMoveTrans.createCheckpointTransaction(
     channelStorage.challengeState,
     channelStorage.finalizesAt,
     states,

--- a/test/contracts/ForceMove/checkpoint.test.ts
+++ b/test/contracts/ForceMove/checkpoint.test.ts
@@ -122,7 +122,7 @@ describe('checkpoint', () => {
         });
       }
 
-      // set expiry time in the future or in the past
+      // compute finalizedAt
       const blockNumber = await provider.getBlockNumber();
       const blockTimestamp = (await provider.getBlock(blockNumber)).timestamp;
       const finalizesAt =
@@ -146,17 +146,16 @@ describe('checkpoint', () => {
       await tx.wait();
       expect(await ForceMove.channelStorageHashes(channelId)).toEqual(challengeExistsHash);
 
-      // sign the states
-      const sigs = await signStates(states, wallets, whoSignedWhat);
+      const signatures = await signStates(states, wallets, whoSignedWhat);
 
-      const transactionsRequest = createCheckpointTransaction(
+      const transactionsRequest = createCheckpointTransaction({
         challengeState,
         finalizesAt,
         states,
-        sigs,
+        signatures,
         whoSignedWhat,
-        setTurnNumRecord,
-      );
+        turnNumRecord: setTurnNumRecord,
+      });
       if (test.reason) {
         const regex = new RegExp(
           '^' + 'VM Exception while processing transaction: revert ' + test.reason + '$',

--- a/test/contracts/ForceMove/refute.test.ts
+++ b/test/contracts/ForceMove/refute.test.ts
@@ -6,7 +6,6 @@ import ForceMoveArtifact from '../../../build/contracts/TESTForceMove.json';
 import countingAppArtifact from '../../../build/contracts/CountingApp.json';
 import {defaultAbiCoder, hexlify, bigNumberify} from 'ethers/utils';
 import {setupContracts, sign, newChallengeClearedEvent, sendTransaction} from '../../test-helpers';
-import {AddressZero} from 'ethers/constants';
 import {Channel, getChannelId} from '../../../src/contract/channel';
 import {State, hashState} from '../../../src/contract/state';
 import {Outcome} from '../../../src/contract/outcome';
@@ -146,7 +145,6 @@ describe('refute', () => {
         const expectedChannelStorage: ChannelStorage = {
           largestTurnNum: declaredTurnNumRecord,
           finalizesAt: '0x0',
-          challengerAddress: AddressZero,
         };
         const expectedChannelStorageHash = hashChannelStorage(expectedChannelStorage);
         expect(await ForceMove.channelStorageHashes(channelId)).toEqual(expectedChannelStorageHash);

--- a/test/contracts/ForceMove/respond.test.ts
+++ b/test/contracts/ForceMove/respond.test.ts
@@ -6,7 +6,6 @@ import ForceMoveArtifact from '../../../build/contracts/TESTForceMove.json';
 import countingAppArtifact from '../../../build/contracts/CountingApp.json';
 import {defaultAbiCoder, hexlify, bigNumberify} from 'ethers/utils';
 import {setupContracts, sign, newChallengeClearedEvent, sendTransaction} from '../../test-helpers';
-import {AddressZero} from 'ethers/constants';
 import {Outcome} from '../../../src/contract/outcome';
 import {Channel, getChannelId} from '../../../src/contract/channel';
 import {State, hashState} from '../../../src/contract/state';
@@ -151,7 +150,6 @@ describe('respond', () => {
         const expectedChannelStorageHash = hashChannelStorage({
           largestTurnNum: declaredTurnNumRecord + 1,
           finalizesAt: '0x0',
-          challengerAddress: AddressZero,
         });
         expect(await ForceMove.channelStorageHashes(channelId)).toEqual(expectedChannelStorageHash);
       }

--- a/test/contracts/NitroAdjudicator/pushOutcome.test.ts
+++ b/test/contracts/NitroAdjudicator/pushOutcome.test.ts
@@ -33,8 +33,6 @@ for (let i = 0; i < 3; i++) {
   wallets[i] = ethers.Wallet.createRandom();
   participants[i] = wallets[i].address;
 }
-const challengerAddress = participants[0];
-
 beforeAll(async () => {
   NitroAdjudicator = await setupContracts(provider, NitroAdjudicatorArtifact);
   ETHAssetHolder = await setupContracts(provider, ETHAssetHolderArtifact);
@@ -87,13 +85,16 @@ describe('pushOutcome', () => {
         challengeDuration: '0x1',
       };
 
+      const challengerAddress = participants[state.turnNum % participants.length];
+
       const initialChannelStorageHash = finalizedOutcomeHash(
         storedTurnNumRecord,
         finalizesAt,
-        challengerAddress,
-        state,
         outcome,
+        state,
+        challengerAddress,
       );
+
       // call public wrapper to set state (only works on test contract)
       const tx = await NitroAdjudicator.setChannelStorageHash(channelId, initialChannelStorageHash);
       await tx.wait();

--- a/test/src/transactions.test.ts
+++ b/test/src/transactions.test.ts
@@ -5,7 +5,7 @@ import {
   createForceMoveTransaction,
   createConcludeTransaction,
   createRespondTransaction,
-  createRespondWithAlternativeTransaction,
+  createCheckpointTransaction,
 } from '../../src/transactions';
 import {ChannelStorage} from '../../src';
 import {AddressZero} from 'ethers/constants';
@@ -101,9 +101,9 @@ describe('transactions', async () => {
       }).toThrowError();
     });
   });
-  describe('respond with alternative transactions', () => {
+  describe('respond with checkpoint transactions', () => {
     it('creates a transaction', async () => {
-      const transactionRequest: TransactionRequest = createRespondWithAlternativeTransaction(
+      const transactionRequest: TransactionRequest = createCheckpointTransaction(
         challengeChannelStorage,
         [signedState],
       );
@@ -112,7 +112,7 @@ describe('transactions', async () => {
     });
     it('throws an error when there is no challenge state', async () => {
       expect(() => {
-        createRespondWithAlternativeTransaction(channelStorage, [signedState]);
+        createCheckpointTransaction(channelStorage, [signedState]);
       }).toThrowError();
     });
   });

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -41,7 +41,6 @@ export const clearedChallengeHash = (turnNumRecord: number = 5) => {
   return hashChannelStorage({
     largestTurnNum: bigNumberify(turnNumRecord).toHexString(),
     finalizesAt: '0x0',
-    challengerAddress: AddressZero,
   });
 };
 

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -50,7 +50,6 @@ export const ongoingChallengeHash = (turnNumRecord: number = 5) => {
     finalizesAt: bigNumberify(1e12).toHexString(),
     challengerAddress: AddressZero,
     outcome: [],
-    state: undefined,
   });
 };
 
@@ -58,11 +57,15 @@ export const finalizedOutcomeHash = (
   turnNumRecord: number = 5,
   finalizesAt: string = toHex(1),
   outcome: Outcome = [],
+  state = undefined,
+  challengerAddress = undefined,
 ) => {
   return hashChannelStorage({
     largestTurnNum: bigNumberify(turnNumRecord).toHexString(),
     finalizesAt,
     outcome,
+    state,
+    challengerAddress,
   });
 };
 

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -10,12 +10,12 @@ import {
 import {AddressZero, HashZero} from 'ethers/constants';
 import {hashChannelStorage} from '../src/contract/channel-storage';
 import {
-  Outcome,
   encodeAllocation,
   hashAssetOutcome,
   encodeGuarantee,
   Guarantee,
   Allocation,
+  Outcome,
 } from '../src/contract/outcome';
 import {State, hashState} from '../src/contract/state';
 import {TransactionRequest, TransactionReceipt} from 'ethers/providers';
@@ -49,21 +49,19 @@ export const ongoingChallengeHash = (turnNumRecord: number = 5) => {
     largestTurnNum: bigNumberify(turnNumRecord).toHexString(),
     finalizesAt: bigNumberify(1e12).toHexString(),
     challengerAddress: AddressZero,
+    outcome: [],
+    state: undefined,
   });
 };
 
 export const finalizedOutcomeHash = (
   turnNumRecord: number = 5,
   finalizesAt: string = toHex(1),
-  challengerAddress: string = AddressZero,
-  state?: State,
-  outcome?: Outcome,
+  outcome: Outcome = [],
 ) => {
   return hashChannelStorage({
     largestTurnNum: bigNumberify(turnNumRecord).toHexString(),
     finalizesAt,
-    state,
-    challengerAddress,
     outcome,
   });
 };


### PR DESCRIPTION
This change
- renames `respondWithAlternativeMove` to `checkpoint`
- lets you call `checkpoint` with any turn number greater than `turnNumRecord`
- lets you increment `turnNumRecord` when the channel is open, by calling `checkpoint`

Other incidental changes:
- `setChannelHash` ensures that open channels have valid channel storage
- `encodeChannelStorage` is implemented, which throws when passed invalid storage data
- a new test description/revert reason technique is used in [checkpoint.test.ts](https://github.com/statechannels/nitro-protocol/blob/e2b404b9175aba62a4ce8b9a9151a88ee49a5749/test/contracts/ForceMove/checkpoint.test.ts#L47-L89)