### PR TITLE
Storage alternative

### DIFF
--- a/contracts/ForceMove.sol
+++ b/contracts/ForceMove.sol
@@ -67,18 +67,14 @@ contract ForceMove {
         require(largestTurnNum >= turnNumRecord, 'Stale challenge!');
 
         // EITHER there is no information stored against channelId at all (OK)
-        if (channelStorageHashes[channelId] != bytes32(0)) {
-            // OR there is, in which case we must check the channel is still open and that the committed turnNumRecord is correct
-            require(
-                keccak256(
-                        abi.encode(
-                            ChannelStorage(turnNumRecord, 0, bytes32(0), address(0), bytes32(0))
-                        )
-                    ) ==
-                    channelStorageHashes[channelId],
-                'Channel is not open or turnNum does not match'
-            );
-        }
+        // OR there is, in which case we must check the channel is still open and that the committed turnNumRecord is correct
+        require(
+            __slotEmptyOrMatchesHash(
+                ChannelStorage(turnNumRecord, 0, bytes32(0), address(0), bytes32(0)),
+                channelStorageHashes[channelId]
+            ),
+            'Channel is not open or turnNum does not match'
+        );
 
         bytes32[] memory stateHashes = new bytes32[](variableParts.length);
         stateHashes = _validTransitionChain(
@@ -134,15 +130,13 @@ contract ForceMove {
             variableParts
         );
 
-        channelStorageHashes[channelId] = keccak256(
-            abi.encode(
-                ChannelStorage(
-                    largestTurnNum,
-                    now + fixedPart.challengeDuration,
-                    stateHashes[variableParts.length - 1],
-                    challenger,
-                    keccak256(abi.encode(variableParts[variableParts.length - 1].outcome))
-                )
+        channelStorageHashes[channelId] = _getHash(
+            ChannelStorage(
+                largestTurnNum,
+                now + fixedPart.challengeDuration,
+                stateHashes[variableParts.length - 1],
+                challenger,
+                keccak256(abi.encode(variableParts[variableParts.length - 1].outcome))
             )
         );
 
@@ -206,18 +200,16 @@ contract ForceMove {
         require(now < finalizesAt, 'Response too late!');
 
         require(
-            keccak256(
-                    abi.encode(
-                        ChannelStorage(
-                            turnNumRecord,
-                            finalizesAt,
-                            challengeStateHash,
-                            challenger,
-                            challengeOutcomeHash
-                        )
-                    )
-                ) ==
-                channelStorageHashes[channelId],
+            _matchesHash(
+                ChannelStorage(
+                    turnNumRecord,
+                    finalizesAt,
+                    challengeStateHash,
+                    challenger,
+                    challengeOutcomeHash
+                ),
+                channelStorageHashes[channelId]
+            ),
             'Challenge State does not match stored version'
         );
 
@@ -306,18 +298,16 @@ contract ForceMove {
         require(now < finalizesAt, 'Refute too late!');
 
         require(
-            keccak256(
-                    abi.encode(
-                        ChannelStorage(
-                            turnNumRecord,
-                            finalizesAt,
-                            challengeStateHash,
-                            challenger, // this is a check that the asserted challenger is in fact the challenger
-                            challengeOutcomeHash
-                        )
-                    )
-                ) ==
-                channelStorageHashes[channelId],
+            _matchesHash(
+                ChannelStorage(
+                    turnNumRecord,
+                    finalizesAt,
+                    challengeStateHash,
+                    challenger, // this is a check that the asserted challenger is in fact the challenger
+                    challengeOutcomeHash
+                ),
+                channelStorageHashes[channelId]
+            ),
             'Challenge State does not match stored version'
         );
 
@@ -371,18 +361,16 @@ contract ForceMove {
 
         // check that the declared finalizesAt and turnNumRecord match storage
         require(
-            keccak256(
-                    abi.encode(
-                        ChannelStorage(
-                            largestTurnNum - 1, // implicit check that we are only incrementing turnNumRecord by 1
-                            channelStorageLite.finalizesAt,
-                            channelStorageLite.stateHash,
-                            channelStorageLite.challengerAddress,
-                            channelStorageLite.outcomeHash
-                        )
-                    )
-                ) ==
-                channelStorageHashes[channelId],
+            _matchesHash(
+                ChannelStorage(
+                    largestTurnNum - 1, // implicit check that we are only incrementing turnNumRecord by 1
+                    channelStorageLite.finalizesAt,
+                    channelStorageLite.stateHash,
+                    channelStorageLite.challengerAddress,
+                    channelStorageLite.outcomeHash
+                ),
+                channelStorageHashes[channelId]
+            ),
             'Challenge State does not match stored version'
         );
 
@@ -427,18 +415,14 @@ contract ForceMove {
         );
 
         // EITHER there is no information stored against channelId at all (OK)
-        if (channelStorageHashes[channelId] != bytes32(0)) {
-            // OR there is, in which case we must check the channel is still open and that the committed turnNumRecord is correct
-            require(
-                keccak256(
-                        abi.encode(
-                            ChannelStorage(turnNumRecord, 0, bytes32(0), address(0), bytes32(0))
-                        )
-                    ) ==
-                    channelStorageHashes[channelId],
-                'Channel is not open or turnNum does not match'
-            );
-        }
+        // OR there is, in which case we must check the channel is still open and that the committed turnNumRecord is correct
+        require(
+            __slotEmptyOrMatchesHash(
+                ChannelStorage(turnNumRecord, 0, bytes32(0), address(0), bytes32(0)),
+                channelStorageHashes[channelId]
+            ),
+            'Channel is not open or turnNum does not match'
+        );
 
         _conclude(
             largestTurnNum,
@@ -477,18 +461,16 @@ contract ForceMove {
         require(now < channelStorageLite.finalizesAt, 'Channel already finalized!');
 
         require(
-            keccak256(
-                    abi.encode(
-                        ChannelStorage(
-                            turnNumRecord,
-                            channelStorageLite.finalizesAt,
-                            channelStorageLite.stateHash, // challengeStateHash
-                            channelStorageLite.challengerAddress,
-                            challengeOutcomeHash
-                        )
-                    )
-                ) ==
-                channelStorageHashes[channelId],
+            _matchesHash(
+                ChannelStorage(
+                    turnNumRecord,
+                    channelStorageLite.finalizesAt,
+                    channelStorageLite.stateHash, // challengeStateHash
+                    channelStorageLite.challengerAddress,
+                    challengeOutcomeHash
+                ),
+                channelStorageHashes[channelId]
+            ),
             'Challenge State does not match stored version'
         );
 
@@ -669,8 +651,8 @@ contract ForceMove {
     }
 
     function _clearChallenge(bytes32 channelId, uint256 newTurnNumRecord) internal {
-        channelStorageHashes[channelId] = keccak256(
-            abi.encode(ChannelStorage(newTurnNumRecord, 0, bytes32(0), address(0), bytes32(0)))
+        channelStorageHashes[channelId] = _getHash(
+            ChannelStorage(newTurnNumRecord, 0, bytes32(0), address(0), bytes32(0))
         );
         emit ChallengeCleared(channelId, newTurnNumRecord);
     }
@@ -709,12 +691,35 @@ contract ForceMove {
         // effects
 
         // set channel storage
-        channelStorageHashes[channelId] = keccak256(
-            abi.encode(ChannelStorage(0, now, bytes32(0), address(0), outcomeHash))
+        channelStorageHashes[channelId] = _getHash(
+            ChannelStorage(0, now, bytes32(0), address(0), outcomeHash)
         );
 
         // emit event
         emit Concluded(channelId);
+    }
+
+    function _getHash(ChannelStorage memory channelStorage)
+        internal
+        pure
+        returns (bytes32 newHash)
+    {
+        uint256 i = uint256(keccak256(abi.encode(channelStorage))) >> 160;
+        i |= channelStorage.turnNumRecord << 160;
+        i |= channelStorage.finalizesAt << 208;
+        return bytes32(i);
+    }
+
+    function _matchesHash(ChannelStorage memory cs, bytes32 h) internal pure returns (bool) {
+        return _getHash(cs) == h;
+    }
+
+    function __slotEmptyOrMatchesHash(ChannelStorage memory cs, bytes32 h)
+        internal
+        pure
+        returns (bool)
+    {
+        return _getHash(cs) == h || _getHash(ChannelStorage(0, 0, 0, address(0), 0)) == h;
     }
 
     // events

--- a/contracts/NitroAdjudicator.sol
+++ b/contracts/NitroAdjudicator.sol
@@ -24,18 +24,16 @@ contract NitroAdjudicator is ForceMove {
         bytes32 outcomeHash = keccak256(abi.encode(outcomeBytes));
 
         require(
-            keccak256(
-                    abi.encode(
-                        ChannelStorage(
-                            turnNumRecord,
-                            finalizesAt,
-                            stateHash,
-                            challengerAddress,
-                            outcomeHash
-                        )
-                    )
-                ) ==
-                channelStorageHashes[channelId],
+            _matchesHash(
+                ChannelStorage(
+                    turnNumRecord,
+                    finalizesAt,
+                    stateHash,
+                    challengerAddress,
+                    outcomeHash
+                ),
+                channelStorageHashes[channelId]
+            ),
             'Submitted data does not match storage'
         );
 

--- a/contracts/POC.sol
+++ b/contracts/POC.sol
@@ -1,0 +1,33 @@
+pragma solidity ^0.5.11;
+pragma experimental ABIEncoderV2;
+
+contract POC {
+    struct ChannelStorage {
+        uint256 turnNumRecord;
+        uint256 finalizesAt;
+        bytes32 stateHash;
+        address challengerAddress;
+        bytes32 outcomeHash;
+    }
+
+    function getHash(ChannelStorage memory channelStorage) public pure returns (uint256 newHash) {
+        newHash = uint256(keccak256(abi.encode(channelStorage))) >> 160;
+        newHash |= channelStorage.turnNumRecord << 160;
+        newHash |= channelStorage.finalizesAt << 208;
+        return newHash;
+    }
+
+    function getData(uint256 storageHash)
+        public
+        pure
+        returns (uint160 fingerprint, uint48 turnNumRecord, uint48 finalizesAt)
+    {
+        fingerprint = uint160(storageHash);
+        turnNumRecord = uint48(storageHash >> 160);
+        finalizesAt = uint48(storageHash >> 208);
+    }
+
+    function matchesHash(ChannelStorage memory cs, uint256 h) public pure returns (bool) {
+        return getHash(cs) == h;
+    }
+}

--- a/contracts/test/TESTForceMove.sol
+++ b/contracts/test/TESTForceMove.sol
@@ -43,7 +43,7 @@ contract TESTForceMove is ForceMove {
     // public setter for channelStorage
 
     function setChannelStorage(bytes32 channelId, ChannelStorage memory channelStorage) public {
-        channelStorageHashes[channelId] = keccak256(abi.encode(channelStorage));
+        channelStorageHashes[channelId] = getHash(channelStorage);
     }
 
     // public setter for channelStorage
@@ -51,4 +51,21 @@ contract TESTForceMove is ForceMove {
     function setChannelStorageHash(bytes32 channelId, bytes32 h) public {
         channelStorageHashes[channelId] = h;
     }
+
+    function getData(uint256 storageHash) public pure returns (uint160, uint48, uint48) {
+        uint160 fingerprint = uint160(storageHash);
+        uint48 turnNumRecord = uint48(storageHash >> 160);
+        uint48 finalizesAt = uint48(storageHash >> 208);
+
+        return (fingerprint, turnNumRecord, finalizesAt);
+    }
+
+    function getHash(ChannelStorage memory channelStorage) public pure returns (bytes32 newHash) {
+        return _getHash(channelStorage);
+    }
+
+    function matchesHash(ChannelStorage memory cs, bytes32 h) public pure returns (bool) {
+        return _matchesHash(cs, h);
+    }
+
 }

--- a/contracts/test/TESTNitroAdjudicator.sol
+++ b/contracts/test/TESTNitroAdjudicator.sol
@@ -43,7 +43,7 @@ contract TESTNitroAdjudicator is NitroAdjudicator {
     // public setter for channelStorage
 
     function setChannelStorage(bytes32 channelId, ChannelStorage memory channelStorage) public {
-        channelStorageHashes[channelId] = keccak256(abi.encode(channelStorage));
+        channelStorageHashes[channelId] = _getHash(channelStorage);
     }
 
     // public setter for channelStorage

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -3,6 +3,7 @@ const ETHAssetHolder = artifacts.require('ETHAssetHolder');
 const ERC20AssetHolder = artifacts.require('ERC20AssetHolder');
 const NitroAdjudicator = artifacts.require('NitroAdjudicator');
 const ConsensusApp = artifacts.require('ConsensusApp');
+const POC = artifacts.require('POC');
 
 module.exports = async function(deployer) {
   deployer.then(async () => {
@@ -20,5 +21,7 @@ module.exports = async function(deployer) {
       TokenInstance.address,
     );
     await deployer.deploy(ConsensusApp);
+
+    await deployer.deploy(POC);
   });
 };

--- a/test/contracts/ForceMove/POC.test.ts
+++ b/test/contracts/ForceMove/POC.test.ts
@@ -1,0 +1,40 @@
+import {ethers} from 'ethers';
+// @ts-ignore
+import POCArtifact from '../../../build/contracts/POC.json';
+// @ts-ignore
+import {setupContracts} from '../../test-helpers';
+import {AddressZero, HashZero} from 'ethers/constants';
+import {hashChannelStorage} from '../../../src/contract/channel-storage';
+
+const provider = new ethers.providers.JsonRpcProvider(
+  `http://localhost:${process.env.DEV_GANACHE_PORT}`,
+);
+let POC: ethers.Contract;
+
+beforeAll(async () => {
+  POC = await setupContracts(provider, POCArtifact);
+});
+
+const description1 = 'It works';
+
+describe('forceMove', () => {
+  it.each`
+    description     | turnNumRecord | finalizesAt | stateHash   | challengerAddress | outcomeHash
+    ${description1} | ${0}          | ${0}        | ${HashZero} | ${AddressZero}    | ${HashZero}
+    ${description1} | ${42}         | ${9001}     | ${HashZero} | ${AddressZero}    | ${HashZero}
+    ${description1} | ${123456}     | ${789}      | ${HashZero} | ${AddressZero}    | ${HashZero}
+  `('$description', async storage => {
+    const {challengerAddress, turnNumRecord} = storage;
+    const hash = await POC.getHash(storage);
+    const {turnNumRecord: currentTurnNumRecord, finalizesAt, fingerprint} = await POC.getData(hash);
+
+    const hashedStorage = hashChannelStorage({
+      challengerAddress,
+      finalizesAt,
+      largestTurnNum: currentTurnNumRecord,
+    });
+    expect(storage).toMatchObject({turnNumRecord, finalizesAt});
+    expect(fingerprint._hex).toEqual(hashedStorage.slice(0, 26));
+    expect(await POC.matchesHash(storage, hash)).toBe(true);
+  });
+});

--- a/test/contracts/ForceMove/respondWithAlternative.test.ts
+++ b/test/contracts/ForceMove/respondWithAlternative.test.ts
@@ -11,10 +11,10 @@ import {
   signStates,
   sendTransaction,
 } from '../../test-helpers';
-import {AddressZero} from 'ethers/constants';
-import {Outcome} from '../../../src/contract/outcome';
+import {AddressZero, One, HashZero} from 'ethers/constants';
+import {Outcome, hashOutcome} from '../../../src/contract/outcome';
 import {Channel, getChannelId} from '../../../src/contract/channel';
-import {State} from '../../../src/contract/state';
+import {State, hashState} from '../../../src/contract/state';
 import {hashChannelStorage} from '../../../src/contract/channel-storage';
 import {createRespondWithAlternativeTransaction} from '../../../src/contract/transaction-creators/force-move';
 
@@ -106,19 +106,17 @@ describe('respondWithAlternative', () => {
       const blockNumber = await provider.getBlockNumber();
       const blockTimestamp = (await provider.getBlock(blockNumber)).timestamp;
       const finalizesAt = expired
-        ? bigNumberify(blockTimestamp)
-            .sub(challengeDuration)
-            .toHexString()
+        ? One.toHexString()
         : bigNumberify(blockTimestamp)
             .add(challengeDuration)
             .toHexString();
 
-      const challengeExistsHash = hashChannelStorage({
-        largestTurnNum: setTurnNumRecord,
+      const challengeExistsHash = await ForceMove.getHash({
+        turnNumRecord: setTurnNumRecord,
         finalizesAt,
-        state: challengeState,
+        stateHash: challenger ? hashState(challengeState) : HashZero,
         challengerAddress: challenger.address,
-        outcome,
+        outcomeHash: outcome ? hashOutcome(outcome) : HashZero,
       });
 
       // call public wrapper to set state (only works on test contract)


### PR DESCRIPTION
This PR implements an example storage strategy that lets us see `turnNumRecord` and `finalizedAt` on the channel state.

The benefits of this strategy include:
- You can tell the turn number and the mode of the channel by querying the chain, rather than filtering through events
- You can implement a ForceMove protocol that makes the following guarantee:
> The turnNumRecord stored on-chain is the turn number of the most recent supported state seen by the adjudicator.

I updated all but one test case in one test file, which essentially passes.

The strategy is outlined in `POC.sol`, with some examples in `POC.test.ts`.

```
// This branch
Contract Name  Method Name             Calls  Min Gas  Max Gas  Average Gas
-------------  ----------------------  -----  -------  -------  -----------
TESTForceMove  setChannelStorageHash   5      45092    45284    45233
TESTForceMove  respondWithAlternative  5      78557    139528   101413

// Master
Contract Name  Method Name             Calls  Min Gas  Max Gas  Average Gas
-------------  ----------------------  -----  -------  -------  -----------
TESTForceMove  setChannelStorageHash   5      46094    46222    46171
TESTForceMove  respondWithAlternative  5      78640    139232   101254
```