### PR TITLE
Introduce _stateSupportedBy function

### DIFF
--- a/docs/adjudicator/_stateSupportedBy.md
+++ b/docs/adjudicator/_stateSupportedBy.md
@@ -1,0 +1,30 @@
+---
+id: state-supported-by
+title: _stateSupportedBy
+---
+
+As we will see in the method definitions later, in order for the chain to accept a channel state, `s`, that channel state must be _supported_ by `n` signatures (where `n = participants.length`).
+The simplest way for this to accomplish this is to provide a sequence of `n` states terminating is state `s`, where each state is signed by its mover and each consecutive pair of states form a valid transition.
+
+ForceMove also allows an optimization where a state can be supported by `n` signatures on a sequence of `m < n` states, provided again that each consecutive pair of those `m` states form a valid transition and further provided each participant has provided a signature on a state later or equal in the sequence than the state for which they were the mover.
+In the extreme, this allows a single state signed by all `n` parties to be accepted by the chain.
+
+## Signature
+
+```solidity
+    function _stateSupportedBy(
+        uint256 largestTurnNum,
+        ForceMoveApp.VariablePart[] memory variableParts,
+        uint8 isFinalCount,
+        bytes32 channelId,
+        FixedPart memory fixedPart,
+        Signature[] memory sigs,
+        uint8[] memory whoSignedWhat // whoSignedWhat[i] is the index of the state in stateHashes that was signed by participants[i]
+    ) internal pure returns (bytes32)
+```
+
+## Implementation
+
+- Check states form a valid transition chain and calculate `stateHashes`, by calling `_validTransitionChain`.
+- Check the signatures on the stateHashes are correct by requiring `_validSignatures`.
+- If checks pass, returns the final element in the `stateHashes` array.

--- a/docs/adjudicator/checkpoint.md
+++ b/docs/adjudicator/checkpoint.md
@@ -52,17 +52,7 @@ Parameters:
 - Check that `finalizesAt > now || finalizesAt == 0`
 - Calculate `storageHash` from `turnNumRecord`, `finalizesAt`, `challengerAddress`, `challengeStateHash`, `challengeOutcomeHash`
 - Check that `channelStorageHashes[channelId] == storageHash`
-- Let `m = variableParts.length`
-- For `i` in `0 .. (m-1)`:
-  - Let `isFinal = i > m - isFinalCount`
-  - Let `turnNum = largestTurnNum + i - m + 1`
-  - Calculate `stateHash[i]` from `fixedPart, channelId, turnNum, variablePart[i], isFinal`
-  - If `i + 1 != m`
-    - Calculate `isFinalAB = [i > m - isFinalCount, i + 1 > m - isFinalCount]`
-    - Calculate `turnNumB = largestTurnNum + i - m + 2`
-    - Ensure `validTransition(nParticipants, isFinalAB, turnNumB, variablePart[i], variablePart[i+1], appDefinition)`
-    - (Other checks are covered by construction)
-- Check that `_validSignatures(largestTurnNum, participants, stateHashes, sigs, whoSignedwhat)`
+- Check that a state with `turnNum = largestTurnNum` is supported by the input data (if there is none, revert). Do this by calling the `_stateSupportedBy` method.
 - Set channelStorage:
   - `turnNumRecord = largestTurnNum`
   - Other fields set to their null values (see [Channel Storage](./channel-storage)).

--- a/docs/adjudicator/conclude.md
+++ b/docs/adjudicator/conclude.md
@@ -3,11 +3,17 @@ id: conclude
 title: conclude
 ---
 
-The conclude methods allow anyone with sufficient on-chain state to immediately finalize an outcome for a channel wihout having to wait for a challenge to expire.
+If a participant signs a state with `isFinal = true`, then in a cooperative channel-closing procedure the other players can countersign that state and broadcast it. Once a full set of `n` such signatures exists \(this set is known as a **finalization proof**\) anyone in possession may use it to finalize the channel on-chain. They would do this by calling `conclude` on the adjudicator.
+
+:::tip
+In Nitro, the existence of this possibility can be relied on \(counterfactually\) to [close a channel off-chain](../auxiliary-protocols#closing-off-chain).
+:::
+
+The conclude methods allow anyone with sufficient off-chain state to immediately finalize an outcome for a channel without having to wait for a challenge to expire.
 
 The off-chain state is submitted (in an optimized format), and once relevant checks have passed, an expired challenge is stored against the `channelId`.
 
-There is a seperate method to call, depending on whether a challenge is ongoing or whether the channel is open.
+There is a separate method to call, depending on whether a challenge is ongoing or whether the channel is open.
 
 ## Specification
 

--- a/docs/adjudicator/force-move.md
+++ b/docs/adjudicator/force-move.md
@@ -50,23 +50,13 @@ Effects:
 - If `channelStorageHashes[channelId] != 0`
   - Calculate `emptyStorageHash = hash(turnNumRecord, 0, 0, 0)`
   - Check that `channelStorageHashes[channelId] = emptyStorageHash`
-- Let `m = variableParts.length`
-- For `i` in `0 .. (m-1)`:
-  - Let `isFinal = i > m - isFinalCount`
-  - Let `turnNum = largestTurnNum + i - m + 1`
-  - Calculate `stateHash[i]` from `fixedPart, channelId, turnNum, variablePart[i], isFinal`
-  - If `i + 1 != m`
-    - Calculate `isFinalAB = [i > m - isFinalCount, i + 1 > m - isFinalCount]`
-    - Calculate `turnNumB = largestTurnNum + i - m + 2`
-    - Ensure `validTransition(nParticipants, isFinalAB, turnNumB, variablePart[i], variablePart[i+1], appDefinition)`
-    - (Other checks are covered by construction)
-- Check that `_validSignatures(largestTurnNum, participants, stateHashes, sigs, whoSignedwhat)`
+- Calculate `supportedStateHash` the hash of the state supported by the input data (if there is none, revert).
 - Calculate `msgHash` as `keccak256(abi.encode(largestTurnNum, channelId, 'forceMove'))`
 - Recover challengerAddress from `msgHash` and `challengerSig` and check that `_isAddressInArray(challengerAddress, participants)`
 - Set channelStorage as the hash of the abi encode of
   - `turnNumRecord = largestTurnNum`
   - `finalizesAt = now + challengeDuration`
-  - `stateHashes[m-1]`
+  - `supportedStateHash`
   - `challengerAddress`
   - `outcomeHash = hash(outcomes[m-1])`
 - Emit a `ChallengeRegistered` event

--- a/docs/adjudicator/transition-rules.md
+++ b/docs/adjudicator/transition-rules.md
@@ -105,14 +105,19 @@ contract CountingApp is ForceMoveApp {
 
 but other examples exist: such as a[ payment channel](https://github.com/magmo/force-move-protocol/blob/master/packages/fmg-payments/contracts/PaymentApp.sol), or games of [Rock Paper Scissors](https://github.com/magmo/apps/blob/master/packages/rps/contracts/RockPaperScissorsGame.sol) and [Tic Tac Toe](https://github.com/magmo/apps/blob/master/packages/tictactoe/contracts/TicTacToeGame.sol).
 
-**Channel setup**  
-Participants must
+## Chains of validTransitions
 
-- exchange some initial states
-- ensure the channel is funded
-- begin execution of the application by exchanging further states
+The definition above applies to a pair of `States`. It is often necessary to verify that a list of `States` has the property that the second `State` in each consecutive pair is a `validTransition`from the first.
 
-**Cooperative channel closing**  
-If a participant signs a state with `isFinal = true`, then in a cooperative channel-closing procedure the other players can countersign that state \(with turnNum still changing appropriately\). Once a full set of `n` such states exists \(this set is known as a **finalization proof**\) anyone in posession may use it to finalize the channel on-chain. They would do this by calling [`conclude`](./conclude) on the adjudicator.
+### Implementation
 
-In Nitro, the existence of this possibility is relied on \(counterfactually\) to close a channel off-chain.
+```solidity
+    function _validTransitionChain(
+        // returns stateHashes array (implies true) else reverts
+        uint256 largestTurnNum,
+        ForceMoveApp.VariablePart[] memory variableParts,
+        uint8 isFinalCount,
+        bytes32 channelId,
+        FixedPart memory fixedPart
+    ) internal pure returns (bytes32[] memory)
+```

--- a/docs/adjudicator/valid-signatures.md
+++ b/docs/adjudicator/valid-signatures.md
@@ -1,15 +1,13 @@
 ---
 id: valid-signatures
-title: validSignatures
+title: _validSignatures
 ---
 
-As we will see in the method definitions later, in order for the chain to accept a channel state, `s`, that channel state must be _supported_ by `n` signatures (where `n = participants.length`).
-The simplest way for this to accomplish this is to provide a sequence of `n` states terminating is state `s`, where each state is signed by its mover and each consecutive pair of states form a valid transition.
+Given an array of state hashes, checks the validity of the supplied signatures.
 
-ForceMove also allows an optimization where a state can be supported by `n` signatures on a sequence of `m < n` states, provided again that each consecutive pair of those `m` states form a valid transition and further provided each participant has provided a signature on a state later or equal in the sequence than the state for which they were the mover.
-In the extreme, this allows a single state signed by all `n` parties to be accepted by the chain.
-
-## Valid Signatures
+:::warning
+Does not check the states to see if they form a chain of valid transitions.
+:::
 
 Internal call
 
@@ -36,8 +34,8 @@ Each signature is a struct:
 ### Requirements:
 
 - There is a signature for each participant:
-  - either on the state for which they are a mover
-  - or on a state that appears after that state in the array
+  - either on the hash of the state for which they are a mover
+  - or on the hash of a state that appears after that state in the array
 
 Some examples:
 

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -6,6 +6,7 @@
       "adjudicator/force-move-intro",
       "adjudicator/state-format",
       "adjudicator/transition-rules",
+      "adjudicator/state-supported-by",
       "adjudicator/valid-signatures",
       "adjudicator/channel-storage",
       "adjudicator/force-move",


### PR DESCRIPTION
This function will check:

- that the input states form a chain of valid transitions
- that the signatures are valid on the stateHashes (in the current sense).

and either reverts if either check fails, or returns the hash of the state that is supported by the input data.

The `_validSignatures` and `_validTransitionChain` functions remain since in some contexts it is convenient to call them directly, and not the wrapper function introduced here. 

This PR includes appropriate changes to the docs.
