### PR TITLE
Fixup conclude

### DIFF
--- a/contracts/ForceMove.sol
+++ b/contracts/ForceMove.sol
@@ -425,7 +425,7 @@ contract ForceMove {
         uint8 numStates,
         uint8[] memory whoSignedWhat,
         Signature[] memory sigs,
-        bytes32 challengeOutcomeHash,
+        bytes32 newOutcomeHash,
         bytes memory channelStorageLiteBytes // This is to avoid a 'stack too deep' error by minimising the number of local variables
     ) public {
         // Calculate channelId from fixed part
@@ -438,7 +438,6 @@ contract ForceMove {
             (ChannelStorageLite)
         );
 
-        require(turnNumRecord > 0, 'TurnNumRecord must be nonzero');
         require(now < channelStorageLite.finalizesAt, 'Channel already finalized!');
 
         require(
@@ -449,7 +448,7 @@ contract ForceMove {
                             channelStorageLite.finalizesAt,
                             channelStorageLite.stateHash, // challengeStateHash
                             channelStorageLite.challengerAddress,
-                            challengeOutcomeHash
+                            channelStorageLite.outcomeHash
                         )
                     )
                 ) ==
@@ -463,7 +462,7 @@ contract ForceMove {
             fixedPart.participants,
             channelId,
             appPartHash,
-            channelStorageLite.outcomeHash,
+            newOutcomeHash,
             sigs,
             whoSignedWhat
         );

--- a/src/contract/transaction-creators/force-move.ts
+++ b/src/contract/transaction-creators/force-move.ts
@@ -117,7 +117,6 @@ export function createConcludeFromChallengeTransaction(
   const numStates = states.length;
 
   const {outcome} = challengeState;
-  const challengeOutcomeHash = hashOutcome(outcome);
 
   const challengerAddress = participants[challengeState.turnNum % participants.length];
   const channelStorageLiteBytes = encodeChannelStorageLite({
@@ -127,6 +126,8 @@ export function createConcludeFromChallengeTransaction(
     challengerAddress,
   });
 
+  const newOutcomeHash = hashOutcome(lastState.outcome);
+
   const data = ForceMoveContractInterface.functions.concludeFromChallenge.encode([
     turnNumRecord,
     largestTurnNum,
@@ -135,7 +136,7 @@ export function createConcludeFromChallengeTransaction(
     numStates,
     whoSignedWhat,
     signatures,
-    challengeOutcomeHash,
+    newOutcomeHash,
     channelStorageLiteBytes,
   ]);
   return {data, gasLimit: GAS_LIMIT};


### PR DESCRIPTION
This PR fixes the following problems:

- The documentation wrongly states that a `stateHash` is stored when concluding
- The two `outcomeHashes` passed in to `concludeFromChallenge` were confusingly named and ambiguously stored. We now have `outcomeHash` stored in `ChannelStorageLite`, and `newOutcomeHash` passed in as a separate parameter. The first hash is checked, the second hash is set. 
- We were needlessly requiring `turnNumRecord > 0`